### PR TITLE
Minor Correction

### DIFF
--- a/printemps/model/verifier.h
+++ b/printemps/model/verifier.h
@@ -37,8 +37,8 @@ constexpr void verify_and_correct_selection_variables_initial_values(
     const bool                       a_IS_ENABLED_PRINT) {
     utility::print_single_line(a_IS_ENABLED_PRINT);
     utility::print_message(
-        "Verifying the initial values of the binary decisionvariables included "
-        "in the selection constraints...",
+        "Verifying the initial values of the binary decision variables "
+        "included in the selection constraints...",
         a_IS_ENABLED_PRINT);
 
     for (auto &&selection : a_model->selections()) {

--- a/printemps/solver/solver.h
+++ b/printemps/solver/solver.h
@@ -946,12 +946,12 @@ Result<T_Variable, T_Expression> solve(
             /**
              * Tighten the local penalty coefficients.
              */
-            double total_penalty           = 0.0;
+            double total_violation         = 0.0;
             double total_squared_violation = 0.0;
             for (const auto& proxy : result_local_augmented_incumbent_solution
                                          .violation_value_proxies) {
                 for (const auto& element : proxy.flat_indexed_values()) {
-                    total_penalty += element;
+                    total_violation += element;
                     total_squared_violation += element * element;
                 }
             }
@@ -968,7 +968,7 @@ Result<T_Variable, T_Expression> solve(
 
                 for (auto&& constraint : proxy.flat_indexed_constraints()) {
                     double delta_penalty_constant =
-                        std::max(0.0, gap) / total_penalty;
+                        std::max(0.0, gap) / total_violation;
                     double delta_penalty_proportional =
                         std::max(0.0, gap) / total_squared_violation *
                         violation_values[constraint.flat_index()];


### PR DESCRIPTION
This PR fixes a typo in a message and changes a variable name `total_penalty` to `total_violation ` in solver.h.