### PR TITLE
Feature MPS Solver

### DIFF
--- a/application/printemps/utility/mps_utility.h
+++ b/application/printemps/utility/mps_utility.h
@@ -729,6 +729,52 @@ std::unordered_map<std::string, int> read_solution(
 
     return solution;
 }
+
+/*****************************************************************************/
+std::unordered_set<std::string> read_variable_names(
+    const std::string &a_FILE_NAME) {
+    std::unordered_set<std::string> variable_names;
+    std::vector<std::string>        lines;
+    std::string                     item;
+
+    /**
+     * Read and store entire part of the variable names file.
+     */
+    {
+        std::ifstream ifs;
+        std::string   buffer;
+
+        ifs.open(a_FILE_NAME.c_str());
+        if (ifs.fail()) {
+            throw std::logic_error(utility::format_error_location(
+                __FILE__, __LINE__, __func__,
+                "Cannot open the specified solution file: " + a_FILE_NAME));
+        }
+        while (std::getline(ifs, buffer)) {
+            lines.push_back(buffer);
+        }
+        ifs.close();
+    }
+
+    /**
+     * Parse the variable names file.
+     */
+    for (const auto &line : lines) {
+        std::stringstream        stream(line);
+        std::vector<std::string> items;
+        while (stream >> item) {
+            items.push_back(item);
+        }
+        int ITEMS_SIZE = items.size();
+
+        if (ITEMS_SIZE == 0) {
+            continue;
+        }
+        variable_names.insert(items[0]);
+    }
+
+    return variable_names;
+}
 }  // namespace utility
 }  // namespace printemps
 #endif

--- a/printemps/model/model.h
+++ b/printemps/model/model.h
@@ -1951,6 +1951,32 @@ class Model {
     }
 
     /*************************************************************************/
+    constexpr void fix_variables(
+        const std::unordered_map<std::string, int> &a_SOLUTION) {
+        for (auto &&proxy : m_variable_proxies) {
+            for (auto &&variable : proxy.flat_indexed_variables()) {
+                if (a_SOLUTION.find(variable.name()) != a_SOLUTION.end()) {
+                    variable.fix_by(a_SOLUTION.at(variable.name()));
+                }
+            }
+        }
+    }
+
+    /*************************************************************************/
+    constexpr void unfix_variables(
+        const std::unordered_set<std::string> &a_VARIABLE_NAMES) {
+        for (auto &&proxy : m_variable_proxies) {
+            for (auto &&variable : proxy.flat_indexed_variables()) {
+                variable.fix_by(0);
+                if (a_VARIABLE_NAMES.find(variable.name()) !=
+                    a_VARIABLE_NAMES.end()) {
+                    variable.unfix();
+                }
+            }
+        }
+    }
+
+    /*************************************************************************/
     ModelSummary export_summary(void) const {
         /// This method cannot be constexpr by clang.
         ModelSummary summary;

--- a/test/model/test_model.cpp
+++ b/test/model/test_model.cpp
@@ -2800,6 +2800,91 @@ TEST_F(TestModel, convert_to_plain_solution) {
 }
 
 /*****************************************************************************/
+TEST_F(TestModel, import_solution) {
+    printemps::model::Model<int, double> model;
+
+    auto& x = model.create_variable("x");
+    auto& y = model.create_variables("y", 10);
+    auto& z = model.create_variables("z", {20, 30});
+
+    model.setup_unique_name();
+
+    std::unordered_map<std::string, int> solution;
+    solution["x"]         = 1;
+    solution["y[ 0]"]     = 2;
+    solution["y[ 9]"]     = 3;
+    solution["z[ 0,  0]"] = 4;
+    solution["z[19, 19]"] = 5;
+    model.import_solution(solution);
+
+    EXPECT_EQ(x.value(), 1);
+    EXPECT_EQ(y(0).value(), 2);
+    EXPECT_EQ(y(9).value(), 3);
+    EXPECT_EQ(z(0, 0).value(), 4);
+    EXPECT_EQ(z(19, 19).value(), 5);
+}
+
+/*****************************************************************************/
+TEST_F(TestModel, fix_variables) {
+    printemps::model::Model<int, double> model;
+
+    auto& x = model.create_variable("x");
+    auto& y = model.create_variables("y", 10);
+    auto& z = model.create_variables("z", {20, 30});
+
+    model.setup_unique_name();
+
+    std::unordered_map<std::string, int> solution;
+    solution["x"]         = 1;
+    solution["y[ 0]"]     = 2;
+    solution["y[ 9]"]     = 3;
+    solution["z[ 0,  0]"] = 4;
+    solution["z[19, 19]"] = 5;
+    model.fix_variables(solution);
+
+    EXPECT_EQ(1, x.value());
+    EXPECT_EQ(2, y(0).value());
+    EXPECT_EQ(3, y(9).value());
+    EXPECT_EQ(4, z(0, 0).value());
+    EXPECT_EQ(5, z(19, 19).value());
+
+    EXPECT_EQ(true, x.is_fixed());
+    EXPECT_EQ(true, y(0).is_fixed());
+    EXPECT_EQ(true, y(9).is_fixed());
+    EXPECT_EQ(true, z(0, 0).is_fixed());
+    EXPECT_EQ(true, z(19, 19).is_fixed());
+}
+
+/*****************************************************************************/
+TEST_F(TestModel, unfix_variables) {
+    printemps::model::Model<int, double> model;
+
+    auto& x = model.create_variable("x");
+    auto& y = model.create_variables("y", 10);
+    auto& z = model.create_variables("z", {20, 30});
+
+    model.setup_unique_name();
+
+    std::unordered_set<std::string> mutable_variable_names;
+    mutable_variable_names.insert("x");
+    mutable_variable_names.insert("y[ 0]");
+    mutable_variable_names.insert("y[ 9]");
+    mutable_variable_names.insert("z[ 0,  0]");
+    mutable_variable_names.insert("z[19, 19]");
+    model.unfix_variables(mutable_variable_names);
+
+    EXPECT_EQ(false, x.is_fixed());
+    EXPECT_EQ(false, y(0).is_fixed());
+    EXPECT_EQ(true, y(1).is_fixed());
+    EXPECT_EQ(true, y(8).is_fixed());
+    EXPECT_EQ(false, y(9).is_fixed());
+    EXPECT_EQ(false, z(0, 0).is_fixed());
+    EXPECT_EQ(true, z(0, 1).is_fixed());
+    EXPECT_EQ(true, z(19, 18).is_fixed());
+    EXPECT_EQ(false, z(19, 19).is_fixed());
+}
+
+/*****************************************************************************/
 TEST_F(TestModel, export_summary) {
     printemps::model::Model<int, double> model("name");
 


### PR DESCRIPTION
This PR implements new command line options for the `mps_solver`, `-m` and `-f` which respectively specify mutable and fixed variables.

The option `-m` requires a file name which includes mutable variable names as follows:
```
x_0
x_1
x_2
```

The option `-v` requires a file name includes lists fixed variable names and values as  follows:
```
x_0    1
x_1    1 
x_2    1
```

The options `-m` and `-f` cannot be activated simultaneously.