### PR TITLE
Feature extract intermediate variables

### DIFF
--- a/example/sudoku.cpp
+++ b/example/sudoku.cpp
@@ -139,8 +139,8 @@ int main(void) {
     /// Run solver
     /*************************************************************************/
     printemps::solver::Option option;
-    option.verbose                   = printemps::solver::Full;
-    option.tabu_search.iteration_max = 500;
+    option.verbose       = printemps::solver::Full;
+    option.iteration_max = 1000;
 
     auto result = printemps::solver::solve(&model, option);
 

--- a/printemps/neighborhood/chain_move_generator.h
+++ b/printemps/neighborhood/chain_move_generator.h
@@ -109,7 +109,84 @@ class ChainMoveGenerator
     inline constexpr void sort_moves(void) {
         std::sort(this->m_moves.begin(), this->m_moves.end(),
                   [](const auto &a_LHS, const auto &a_RHS) {
-                      return a_LHS.overlap_rate > a_RHS.overlap_rate;
+                      /**
+                       * Firstly, compare the overlap rates.
+                       */
+                      auto overlap_difference =
+                          a_LHS.overlap_rate - a_RHS.overlap_rate;
+                      if (overlap_difference > constant::EPSILON_10) {
+                          return true;
+                      } else if (overlap_difference < -constant::EPSILON_10) {
+                          return false;
+                      }
+
+                      /**
+                       * Secondly, compare the hashes
+                       */
+                      if (a_LHS.hash > a_LHS.hash) {
+                          return true;
+                      } else if (a_LHS.hash < a_LHS.hash) {
+                          return false;
+                      }
+
+                      /**
+                       * Thirdly, compare the number of alterations.
+                       */
+                      int alterations_size_difference =
+                          a_LHS.alterations.size() - a_RHS.alterations.size();
+                      if (alterations_size_difference > 0) {
+                          return true;
+                      } else if (alterations_size_difference < 0) {
+                          return false;
+                      }
+
+                      /**
+                       * Fourthly, compare the number of related constraints.
+                       */
+                      int related_constraints_size_difference =
+                          a_LHS.related_constraint_ptrs.size() -
+                          a_RHS.related_constraint_ptrs.size();
+
+                      if (related_constraints_size_difference > 0) {
+                          return true;
+                      } else if (related_constraints_size_difference < 0) {
+                          return false;
+                      }
+
+                      /**
+                       * Fifthly, compare the addresses of variables.
+                       */
+                      const int ALTERATIONS_SIZE = a_LHS.alterations.size();
+
+                      for (auto i = 0; i < ALTERATIONS_SIZE; i++) {
+                          int address_difference  //
+                              = reinterpret_cast<std::uint_fast64_t>(
+                                    a_LHS.alterations[i].first) -
+                                reinterpret_cast<std::uint_fast64_t>(
+                                    a_RHS.alterations[i].first);
+                          if (address_difference > 0) {
+                              return true;
+                          } else if (address_difference < 0) {
+                              return false;
+                          }
+                      }
+
+                      /**
+                       * Finally, compare the values of variables.
+                       */
+
+                      for (auto i = 0; i < ALTERATIONS_SIZE; i++) {
+                          int value_difference  //
+                              = a_LHS.alterations[i].second -
+                                a_RHS.alterations[i].second;
+
+                          if (value_difference > 0) {
+                              return true;
+                          } else if (value_difference < 0) {
+                              return false;
+                          }
+                      }
+                      return false;
                   });
     }
 

--- a/printemps/neighborhood/move.h
+++ b/printemps/neighborhood/move.h
@@ -132,10 +132,10 @@ constexpr bool has_feasibility_not_improvable_variable(
     const Move<T_Variable, T_Expression> &a_MOVE) {
     for (const auto &alteration : a_MOVE.alterations) {
         if (!alteration.first->is_feasibility_improvable()) {
-            return false;
+            return true;
         }
     }
-    return true;
+    return false;
 };
 
 /*****************************************************************************/

--- a/printemps/presolver/intermediate_variable_extractor.h
+++ b/printemps/presolver/intermediate_variable_extractor.h
@@ -24,7 +24,7 @@ namespace presolver {
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
 constexpr int extract_independent_intermediate_variables(
-    model::Model<T_Variable, T_Expression> *a_model,  //
+    model::Model<T_Variable, T_Expression> *a_model_ptr,  //
     const bool                              a_IS_ENABLED_PRINT) {
     utility::print_single_line(a_IS_ENABLED_PRINT);
     utility::print_message("Extracting independent intermediate variables...",
@@ -35,7 +35,7 @@ constexpr int extract_independent_intermediate_variables(
         intermediate_variable_counts;
 
     for (auto &&constraint_ptr :
-         a_model->constraint_type_reference().intermediate_ptrs) {
+         a_model_ptr->constraint_type_reference().intermediate_ptrs) {
         auto intermediate_variable_ptr =
             constraint_ptr->intermediate_variable_ptr();
         if (intermediate_variable_counts.find(intermediate_variable_ptr) !=
@@ -50,7 +50,7 @@ constexpr int extract_independent_intermediate_variables(
         additional_constraints;
 
     for (auto &&constraint_ptr :
-         a_model->constraint_type_reference().intermediate_ptrs) {
+         a_model_ptr->constraint_type_reference().intermediate_ptrs) {
         if (!constraint_ptr->is_enabled()) {
             continue;
         }
@@ -80,7 +80,7 @@ constexpr int extract_independent_intermediate_variables(
                     sign * modified_expression >=
                     intermediate_variable_ptr->lower_bound());
                 additional_constraints.back().set_name(constraint_ptr->name() +
-                                                       "_lower");
+                                                       "_greater");
             }
 
             if (constraint_ptr->has_intermediate_upper_bound()) {
@@ -88,7 +88,7 @@ constexpr int extract_independent_intermediate_variables(
                     sign * modified_expression <=
                     intermediate_variable_ptr->upper_bound());
                 additional_constraints.back().set_name(constraint_ptr->name() +
-                                                       "_upper");
+                                                       "_less");
             }
             number_of_newly_extracted_independent_intermediate_vairables++;
         }
@@ -96,13 +96,15 @@ constexpr int extract_independent_intermediate_variables(
 
     if (additional_constraints.size() > 0) {
         int   count                       = 0;
-        auto &additional_constraint_proxy = a_model->create_constraints(
+        auto &additional_constraint_proxy = a_model_ptr->create_constraints(
             "additional", additional_constraints.size());
         for (auto &&constraint : additional_constraints) {
-            additional_constraint_proxy(count++) = constraint;
-            utility::print_info(
+            additional_constraint_proxy(count) = constraint;
+            additional_constraint_proxy(count).set_name(constraint.name());
+            utility::print_message(
                 "An extra constraint " + constraint.name() + " was added.",
                 a_IS_ENABLED_PRINT);
+            count++;
         }
     }
 
@@ -113,7 +115,7 @@ constexpr int extract_independent_intermediate_variables(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
 constexpr int eliminate_independent_intermediate_variables(
-    model::Model<T_Variable, T_Expression> *a_model,  //
+    model::Model<T_Variable, T_Expression> *a_model_ptr,  //
     const bool                              a_IS_ENABLED_PRINT) {
     utility::print_single_line(a_IS_ENABLED_PRINT);
     utility::print_message("Eliminating independent intermediate variables...",
@@ -123,10 +125,11 @@ constexpr int eliminate_independent_intermediate_variables(
 
     /// Objective
     {
-        auto sensitivities = a_model->objective().expression().sensitivities();
+        auto sensitivities =
+            a_model_ptr->objective().expression().sensitivities();
 
         for (auto &&variable_ptr :
-             a_model->variable_reference().intermediate_variable_ptrs) {
+             a_model_ptr->variable_reference().intermediate_variable_ptrs) {
             if (sensitivities.find(variable_ptr) != sensitivities.end()) {
                 auto dependent_constraint_ptr =
                     variable_ptr->dependent_constraint_ptr();
@@ -135,7 +138,7 @@ constexpr int eliminate_independent_intermediate_variables(
 
                 double sign = sensitivities.at(variable_ptr) > 0 ? -1.0 : 1.0;
 
-                a_model->objective().expression().substitute(
+                a_model_ptr->objective().expression().substitute(
                     variable_ptr,
                     sign * dependent_constraint_ptr->expression());
                 number_of_newly_eliminated_independent_intermediate_vairables++;
@@ -151,11 +154,11 @@ constexpr int eliminate_independent_intermediate_variables(
 
     /// Constraint
     for (auto &&constrinat_ptr :
-         a_model->constraint_reference().constraint_ptrs) {
+         a_model_ptr->constraint_reference().constraint_ptrs) {
         auto sensitivities = constrinat_ptr->expression().sensitivities();
 
         for (auto &&variable_ptr :
-             a_model->variable_reference().intermediate_variable_ptrs) {
+             a_model_ptr->variable_reference().intermediate_variable_ptrs) {
             if (constrinat_ptr == variable_ptr->dependent_constraint_ptr()) {
                 continue;
             }

--- a/printemps/presolver/selection_extractor.h
+++ b/printemps/presolver/selection_extractor.h
@@ -48,7 +48,7 @@ convert_to_selections(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
 constexpr void extract_selections_by_defined_order(
-    model::Model<T_Variable, T_Expression> *a_model,
+    model::Model<T_Variable, T_Expression> *a_model_ptr,
     const bool                              a_IS_ENABLED_PRINT) {
     utility::print_single_line(a_IS_ENABLED_PRINT);
     utility::print_message("Extracting selection by defined order...",
@@ -57,7 +57,7 @@ constexpr void extract_selections_by_defined_order(
     std::vector<model::Selection<T_Variable, T_Expression>> selections;
     std::vector<model::Selection<T_Variable, T_Expression>> raw_selections =
         convert_to_selections(
-            a_model->constraint_type_reference().set_partitioning_ptrs);
+            a_model_ptr->constraint_type_reference().set_partitioning_ptrs);
 
     std::vector<model::Variable<T_Variable, T_Expression> *>
         extracted_variable_ptrs;
@@ -98,7 +98,7 @@ constexpr void extract_selections_by_defined_order(
         }
     }
 
-    a_model->set_selections(selections);
+    a_model_ptr->set_selections(selections);
 
     utility::print_message("Done.", a_IS_ENABLED_PRINT);
 }
@@ -106,7 +106,7 @@ constexpr void extract_selections_by_defined_order(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
 constexpr void extract_selections_by_number_of_variables_order(
-    model::Model<T_Variable, T_Expression> *a_model,             //
+    model::Model<T_Variable, T_Expression> *a_model_ptr,         //
     const bool                              a_IS_SMALLER_ORDER,  //
     const bool                              a_IS_ENABLED_PRINT) {
     utility::print_single_line(a_IS_ENABLED_PRINT);
@@ -123,7 +123,7 @@ constexpr void extract_selections_by_number_of_variables_order(
     std::vector<model::Selection<T_Variable, T_Expression>> selections;
     std::vector<model::Selection<T_Variable, T_Expression>> raw_selections =
         convert_to_selections(
-            a_model->constraint_type_reference().set_partitioning_ptrs);
+            a_model_ptr->constraint_type_reference().set_partitioning_ptrs);
 
     if (a_IS_SMALLER_ORDER) {
         std::sort(raw_selections.begin(), raw_selections.end(),
@@ -178,7 +178,7 @@ constexpr void extract_selections_by_number_of_variables_order(
         }
     }
 
-    a_model->set_selections(selections);
+    a_model_ptr->set_selections(selections);
 
     utility::print_message("Done.", a_IS_ENABLED_PRINT);
 }
@@ -186,7 +186,7 @@ constexpr void extract_selections_by_number_of_variables_order(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
 constexpr void extract_independent_selections(
-    model::Model<T_Variable, T_Expression> *a_model,
+    model::Model<T_Variable, T_Expression> *a_model_ptr,
     const bool                              a_IS_ENABLED_PRINT) {
     utility::print_single_line(a_IS_ENABLED_PRINT);
     utility::print_message("Extracting independent selection variables...",
@@ -195,7 +195,7 @@ constexpr void extract_independent_selections(
     std::vector<model::Selection<T_Variable, T_Expression>> selections;
     std::vector<model::Selection<T_Variable, T_Expression>> raw_selections =
         convert_to_selections(
-            a_model->constraint_type_reference().set_partitioning_ptrs);
+            a_model_ptr->constraint_type_reference().set_partitioning_ptrs);
 
     std::vector<model::Variable<T_Variable, T_Expression> *>
         extracted_variable_ptrs;
@@ -244,7 +244,7 @@ constexpr void extract_independent_selections(
         }
     }
 
-    a_model->set_selections(selections);
+    a_model_ptr->set_selections(selections);
 
     utility::print_message("Done.", a_IS_ENABLED_PRINT);
 }
@@ -252,7 +252,7 @@ constexpr void extract_independent_selections(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
 constexpr void extract_selections(
-    model::Model<T_Variable, T_Expression> *a_model,  //
+    model::Model<T_Variable, T_Expression> *a_model_ptr,  //
     const model::SelectionMode &            a_SELECTION_MODE,
     const bool                              a_IS_ENABLED_PRINT) {
     switch (a_SELECTION_MODE) {
@@ -260,24 +260,24 @@ constexpr void extract_selections(
             break;
         }
         case model::SelectionMode::Defined: {
-            extract_selections_by_defined_order(a_model,  //
+            extract_selections_by_defined_order(a_model_ptr,  //
                                                 a_IS_ENABLED_PRINT);
             break;
         }
         case model::SelectionMode::Smaller: {
-            extract_selections_by_number_of_variables_order(a_model,  //
-                                                            true,     //
+            extract_selections_by_number_of_variables_order(a_model_ptr,  //
+                                                            true,         //
                                                             a_IS_ENABLED_PRINT);
             break;
         }
         case model::SelectionMode::Larger: {
-            extract_selections_by_number_of_variables_order(a_model,  //
-                                                            false,    //
+            extract_selections_by_number_of_variables_order(a_model_ptr,  //
+                                                            false,        //
                                                             a_IS_ENABLED_PRINT);
             break;
         }
         case model::SelectionMode::Independent: {
-            extract_independent_selections(a_model,  //
+            extract_independent_selections(a_model_ptr,  //
                                            a_IS_ENABLED_PRINT);
             break;
         }

--- a/printemps/solver/incumbent_holder.h
+++ b/printemps/solver/incumbent_holder.h
@@ -118,7 +118,7 @@ class IncumbentHolder {
 
     /*************************************************************************/
     constexpr int try_update_incumbent(
-        model::Model<T_Variable, T_Expression> *a_model,
+        model::Model<T_Variable, T_Expression> *a_model_ptr,
         const solution::SolutionScore &         a_SCORE) {
         /// solution here defined is not substituted when no improvement
         solution::Solution<T_Variable, T_Expression> solution;
@@ -132,7 +132,7 @@ class IncumbentHolder {
                 STATUS_LOCAL_AUGMENTED_INCUMBENT_UPDATE;
 
             if (!is_solution_updated) {
-                solution            = a_model->export_solution();
+                solution            = a_model_ptr->export_solution();
                 is_solution_updated = true;
             }
 
@@ -148,7 +148,7 @@ class IncumbentHolder {
                 STATUS_GLOBAL_AUGMENTED_INCUMBENT_UPDATE;
 
             if (!is_solution_updated) {
-                solution            = a_model->export_solution();
+                solution            = a_model_ptr->export_solution();
                 is_solution_updated = true;
             }
 
@@ -167,7 +167,7 @@ class IncumbentHolder {
                     IncumbentHolderConstant::STATUS_FEASIBLE_INCUMBENT_UPDATE;
 
                 if (!is_solution_updated) {
-                    solution            = a_model->export_solution();
+                    solution            = a_model_ptr->export_solution();
                     is_solution_updated = true;
                 }
 

--- a/printemps/solver/memory.h
+++ b/printemps/solver/memory.h
@@ -29,8 +29,8 @@ class Memory {
 
     /*************************************************************************/
     template <class T_Variable, class T_Expression>
-    Memory(model::Model<T_Variable, T_Expression> *a_model) {
-        this->setup(a_model);
+    Memory(model::Model<T_Variable, T_Expression> *a_model_ptr) {
+        this->setup(a_model_ptr);
     }
 
     /*************************************************************************/
@@ -49,7 +49,7 @@ class Memory {
     /*************************************************************************/
     template <class T_Variable, class T_Expression>
     inline constexpr void setup(
-        model::Model<T_Variable, T_Expression> *a_model) {
+        model::Model<T_Variable, T_Expression> *a_model_ptr) {
         this->initialize();
         /**
          * Short-term memory:
@@ -60,16 +60,17 @@ class Memory {
          * last_update_iterations[proxy_index][index] in
          * tabu_search_move_score.h can return finite integer value.
          */
-        m_last_update_iterations = a_model->generate_variable_parameter_proxies(
-            MemoryConstant::INITIAL_LAST_UPDATE_ITERATION);
+        m_last_update_iterations =
+            a_model_ptr->generate_variable_parameter_proxies(
+                MemoryConstant::INITIAL_LAST_UPDATE_ITERATION);
 
         /* Long-term memory:
          * The Long-term memory records the number of times which each variable
          * has been updated. The initial value of the long-term memory is 0.
          */
-        m_update_counts = a_model->generate_variable_parameter_proxies(0);
+        m_update_counts = a_model_ptr->generate_variable_parameter_proxies(0);
 
-        m_variable_names = a_model->variable_names();
+        m_variable_names = a_model_ptr->variable_names();
     }
 
     /*************************************************************************/
@@ -191,6 +192,18 @@ class Memory {
         for (auto &&proxy : m_last_update_iterations) {
             for (auto &&value : proxy.flat_indexed_values()) {
                 value = MemoryConstant::INITIAL_LAST_UPDATE_ITERATION;
+            }
+        }
+    }
+    /*************************************************************************/
+    inline void revert_last_update_iterations(const int a_ITERATION) {
+        /// This method cannot be constexpr.
+        for (auto &&proxy : m_last_update_iterations) {
+            for (auto &&value : proxy.flat_indexed_values()) {
+                if (value > a_ITERATION) {
+                    value = MemoryConstant::INITIAL_LAST_UPDATE_ITERATION;
+                }
+                value -= (a_ITERATION + 1);
             }
         }
     }

--- a/printemps/verifier/verifier.h
+++ b/printemps/verifier/verifier.h
@@ -11,18 +11,18 @@ namespace verifier {
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
 constexpr void verify_problem(
-    model::Model<T_Variable, T_Expression> *a_model,  //
+    model::Model<T_Variable, T_Expression> *a_model_ptr,  //
     const bool                              a_IS_ENABLED_PRINT) {
     utility::print_single_line(a_IS_ENABLED_PRINT);
     utility::print_message("Verifying the problem...", a_IS_ENABLED_PRINT);
 
-    if (a_model->variable_proxies().size() == 0) {
+    if (a_model_ptr->variable_proxies().size() == 0) {
         throw std::logic_error(utility::format_error_location(
             __FILE__, __LINE__, __func__,
             "No decision variables are defined."));
     }
-    if (a_model->constraint_proxies().size() == 0 &&
-        !a_model->is_defined_objective()) {
+    if (a_model_ptr->constraint_proxies().size() == 0 &&
+        !a_model_ptr->is_defined_objective()) {
         throw std::logic_error(utility::format_error_location(
             __FILE__, __LINE__, __func__,
             "Neither objective nor constraint functions are defined."));
@@ -33,7 +33,7 @@ constexpr void verify_problem(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
 constexpr void verify_and_correct_selection_variables_initial_values(
-    model::Model<T_Variable, T_Expression> *a_model,                 //
+    model::Model<T_Variable, T_Expression> *a_model_ptr,             //
     const bool                              a_IS_ENABLED_CORRECTON,  //
     const bool                              a_IS_ENABLED_PRINT) {
     utility::print_single_line(a_IS_ENABLED_PRINT);
@@ -42,7 +42,7 @@ constexpr void verify_and_correct_selection_variables_initial_values(
         "included in the selection constraints...",
         a_IS_ENABLED_PRINT);
 
-    for (auto &&selection : a_model->selections()) {
+    for (auto &&selection : a_model_ptr->selections()) {
         std::vector<model::Variable<T_Variable, T_Expression> *>
             fixed_selected_variable_ptrs;
         std::vector<model::Variable<T_Variable, T_Expression> *>
@@ -198,7 +198,7 @@ constexpr void verify_and_correct_selection_variables_initial_values(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
 constexpr void verify_and_correct_binary_variables_initial_values(
-    model::Model<T_Variable, T_Expression> *a_model,                 //
+    model::Model<T_Variable, T_Expression> *a_model_ptr,             //
     const bool                              a_IS_ENABLED_CORRECTON,  //
     const bool                              a_IS_ENABLED_PRINT) {
     utility::print_single_line(a_IS_ENABLED_PRINT);
@@ -206,7 +206,7 @@ constexpr void verify_and_correct_binary_variables_initial_values(
         "Verifying the initial values of the binary decision variables.",
         a_IS_ENABLED_PRINT);
 
-    for (auto &&proxy : a_model->variable_proxies()) {
+    for (auto &&proxy : a_model_ptr->variable_proxies()) {
         for (auto &&variable : proxy.flat_indexed_variables()) {
             if (variable.sense() == model::VariableSense::Binary) {
                 if (variable.value() != 0 && variable.value() != 1) {
@@ -248,7 +248,7 @@ constexpr void verify_and_correct_binary_variables_initial_values(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
 constexpr void verify_and_correct_integer_variables_initial_values(
-    model::Model<T_Variable, T_Expression> *a_model,                 //
+    model::Model<T_Variable, T_Expression> *a_model_ptr,             //
     const bool                              a_IS_ENABLED_CORRECTON,  //
     const bool                              a_IS_ENABLED_PRINT) {
     utility::print_single_line(a_IS_ENABLED_PRINT);
@@ -256,7 +256,7 @@ constexpr void verify_and_correct_integer_variables_initial_values(
         "Verifying the initial values of the integer decision variables.",
         a_IS_ENABLED_PRINT);
 
-    for (auto &&proxy : a_model->variable_proxies()) {
+    for (auto &&proxy : a_model_ptr->variable_proxies()) {
         for (auto &&variable : proxy.flat_indexed_variables()) {
             if (variable.sense() == model::VariableSense::Integer &&
                 (variable.value() < variable.lower_bound() ||

--- a/test/model/test_constraint.cpp
+++ b/test/model/test_constraint.cpp
@@ -626,6 +626,8 @@ TEST_F(TestConstraint, setup_constraint_type_min_max) {
                          printemps::model::ConstraintSense::Less);
         constraint.setup_constraint_type();
         EXPECT_TRUE(constraint.is_min_max());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
     }
 
     {
@@ -635,6 +637,30 @@ TEST_F(TestConstraint, setup_constraint_type_min_max) {
                          printemps::model::ConstraintSense::Greater);
         constraint.setup_constraint_type();
         EXPECT_TRUE(constraint.is_min_max());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
+    }
+
+    {
+        auto constraint =
+            printemps::model::Constraint<int, double>::create_instance();
+        constraint.setup(-x + 20 * y + 20 * z,
+                         printemps::model::ConstraintSense::Less);
+        constraint.setup_constraint_type();
+        EXPECT_TRUE(constraint.is_min_max());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_TRUE(constraint.has_intermediate_upper_bound());
+    }
+
+    {
+        auto constraint =
+            printemps::model::Constraint<int, double>::create_instance();
+        constraint.setup(-x - 20 * y - 20 * z,
+                         printemps::model::ConstraintSense::Less);
+        constraint.setup_constraint_type();
+        EXPECT_TRUE(constraint.is_min_max());
+        EXPECT_TRUE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
     }
 
     {
@@ -643,7 +669,9 @@ TEST_F(TestConstraint, setup_constraint_type_min_max) {
         constraint.setup(-x - 20 * y + 20 * z,
                          printemps::model::ConstraintSense::Less);
         constraint.setup_constraint_type();
-        EXPECT_FALSE(constraint.is_min_max());
+        EXPECT_TRUE(constraint.is_min_max());
+        EXPECT_TRUE(constraint.has_intermediate_lower_bound());
+        EXPECT_TRUE(constraint.has_intermediate_upper_bound());
     }
 
     {
@@ -652,7 +680,9 @@ TEST_F(TestConstraint, setup_constraint_type_min_max) {
         constraint.setup(x + 20 * y - 20 * z,
                          printemps::model::ConstraintSense::Greater);
         constraint.setup_constraint_type();
-        EXPECT_FALSE(constraint.is_min_max());
+        EXPECT_TRUE(constraint.is_min_max());
+        EXPECT_TRUE(constraint.has_intermediate_lower_bound());
+        EXPECT_TRUE(constraint.has_intermediate_upper_bound());
     }
 
     {
@@ -662,6 +692,8 @@ TEST_F(TestConstraint, setup_constraint_type_min_max) {
                          printemps::model::ConstraintSense::Less);
         constraint.setup_constraint_type();
         EXPECT_FALSE(constraint.is_min_max());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
     }
 
     {
@@ -671,6 +703,8 @@ TEST_F(TestConstraint, setup_constraint_type_min_max) {
                          printemps::model::ConstraintSense::Less);
         constraint.setup_constraint_type();
         EXPECT_FALSE(constraint.is_min_max());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
     }
 
     {
@@ -680,6 +714,8 @@ TEST_F(TestConstraint, setup_constraint_type_min_max) {
                          printemps::model::ConstraintSense::Less);
         constraint.setup_constraint_type();
         EXPECT_FALSE(constraint.is_min_max());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
     }
 }
 
@@ -697,6 +733,8 @@ TEST_F(TestConstraint, setup_constraint_type_max_min) {
                          printemps::model::ConstraintSense::Greater);
         constraint.setup_constraint_type();
         EXPECT_TRUE(constraint.is_max_min());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
     }
 
     {
@@ -706,6 +744,30 @@ TEST_F(TestConstraint, setup_constraint_type_max_min) {
                          printemps::model::ConstraintSense::Less);
         constraint.setup_constraint_type();
         EXPECT_TRUE(constraint.is_max_min());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
+    }
+
+    {
+        auto constraint =
+            printemps::model::Constraint<int, double>::create_instance();
+        constraint.setup(-x + 20 * y + 20 * z,
+                         printemps::model::ConstraintSense::Greater);
+        constraint.setup_constraint_type();
+        EXPECT_TRUE(constraint.is_max_min());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_TRUE(constraint.has_intermediate_upper_bound());
+    }
+
+    {
+        auto constraint =
+            printemps::model::Constraint<int, double>::create_instance();
+        constraint.setup(-x - 20 * y - 20 * z,
+                         printemps::model::ConstraintSense::Greater);
+        constraint.setup_constraint_type();
+        EXPECT_TRUE(constraint.is_max_min());
+        EXPECT_TRUE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
     }
 
     {
@@ -714,7 +776,9 @@ TEST_F(TestConstraint, setup_constraint_type_max_min) {
         constraint.setup(-x - 20 * y + 20 * z,
                          printemps::model::ConstraintSense::Greater);
         constraint.setup_constraint_type();
-        EXPECT_FALSE(constraint.is_min_max());
+        EXPECT_TRUE(constraint.is_max_min());
+        EXPECT_TRUE(constraint.has_intermediate_lower_bound());
+        EXPECT_TRUE(constraint.has_intermediate_upper_bound());
     }
 
     {
@@ -723,7 +787,9 @@ TEST_F(TestConstraint, setup_constraint_type_max_min) {
         constraint.setup(x + 20 * y - 20 * z,
                          printemps::model::ConstraintSense::Less);
         constraint.setup_constraint_type();
-        EXPECT_FALSE(constraint.is_min_max());
+        EXPECT_TRUE(constraint.is_max_min());
+        EXPECT_TRUE(constraint.has_intermediate_lower_bound());
+        EXPECT_TRUE(constraint.has_intermediate_upper_bound());
     }
 
     {
@@ -733,6 +799,8 @@ TEST_F(TestConstraint, setup_constraint_type_max_min) {
                          printemps::model::ConstraintSense::Greater);
         constraint.setup_constraint_type();
         EXPECT_FALSE(constraint.is_max_min());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
     }
 
     {
@@ -742,6 +810,8 @@ TEST_F(TestConstraint, setup_constraint_type_max_min) {
                          printemps::model::ConstraintSense::Greater);
         constraint.setup_constraint_type();
         EXPECT_FALSE(constraint.is_max_min());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
     }
 
     {
@@ -751,6 +821,8 @@ TEST_F(TestConstraint, setup_constraint_type_max_min) {
                          printemps::model::ConstraintSense::Greater);
         constraint.setup_constraint_type();
         EXPECT_FALSE(constraint.is_max_min());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
     }
 }
 
@@ -769,6 +841,8 @@ TEST_F(TestConstraint, setup_constraint_type_intermediate) {
                          printemps::model::ConstraintSense::Equal);
         constraint.setup_constraint_type();
         EXPECT_TRUE(constraint.is_intermediate());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
         EXPECT_EQ(&x(0), constraint.intermediate_variable_ptr());
     }
 
@@ -779,6 +853,8 @@ TEST_F(TestConstraint, setup_constraint_type_intermediate) {
                          printemps::model::ConstraintSense::Equal);
         constraint.setup_constraint_type();
         EXPECT_TRUE(constraint.is_intermediate());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
         EXPECT_EQ(&x(0), constraint.intermediate_variable_ptr());
     }
 
@@ -788,8 +864,22 @@ TEST_F(TestConstraint, setup_constraint_type_intermediate) {
         constraint.setup(x + 20 * y + 20 * z,
                          printemps::model::ConstraintSense::Equal);
         constraint.setup_constraint_type();
-        EXPECT_FALSE(constraint.is_intermediate());
-        EXPECT_EQ(nullptr, constraint.intermediate_variable_ptr());
+        EXPECT_TRUE(constraint.is_intermediate());
+        EXPECT_TRUE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
+        EXPECT_EQ(&x(0), constraint.intermediate_variable_ptr());
+    }
+
+    {
+        auto constraint =
+            printemps::model::Constraint<int, double>::create_instance();
+        constraint.setup(x + 20 * y - 20 * z,
+                         printemps::model::ConstraintSense::Equal);
+        constraint.setup_constraint_type();
+        EXPECT_TRUE(constraint.is_intermediate());
+        EXPECT_TRUE(constraint.has_intermediate_lower_bound());
+        EXPECT_TRUE(constraint.has_intermediate_upper_bound());
+        EXPECT_EQ(&x(0), constraint.intermediate_variable_ptr());
     }
 
     {
@@ -799,6 +889,8 @@ TEST_F(TestConstraint, setup_constraint_type_intermediate) {
                          printemps::model::ConstraintSense::Equal);
         constraint.setup_constraint_type();
         EXPECT_FALSE(constraint.is_intermediate());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
         EXPECT_EQ(nullptr, constraint.intermediate_variable_ptr());
     }
 
@@ -809,6 +901,8 @@ TEST_F(TestConstraint, setup_constraint_type_intermediate) {
                          printemps::model::ConstraintSense::Equal);
         constraint.setup_constraint_type();
         EXPECT_FALSE(constraint.is_intermediate());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
         EXPECT_EQ(nullptr, constraint.intermediate_variable_ptr());
     }
 
@@ -819,6 +913,8 @@ TEST_F(TestConstraint, setup_constraint_type_intermediate) {
                          printemps::model::ConstraintSense::Equal);
         constraint.setup_constraint_type();
         EXPECT_FALSE(constraint.is_intermediate());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
         EXPECT_EQ(nullptr, constraint.intermediate_variable_ptr());
     }
 
@@ -829,6 +925,8 @@ TEST_F(TestConstraint, setup_constraint_type_intermediate) {
                          printemps::model::ConstraintSense::Equal);
         constraint.setup_constraint_type();
         EXPECT_FALSE(constraint.is_intermediate());
+        EXPECT_FALSE(constraint.has_intermediate_lower_bound());
+        EXPECT_FALSE(constraint.has_intermediate_upper_bound());
         EXPECT_EQ(nullptr, constraint.intermediate_variable_ptr());
     }
 }

--- a/test/model/test_expression.cpp
+++ b/test/model/test_expression.cpp
@@ -402,12 +402,14 @@ TEST_F(TestExpression, mutable_variable_sensitivities) {
     auto negative_mutable_variable_sensitivities =
         expression.negative_mutable_variable_sensitivities();
 
-    EXPECT_EQ(3, mutable_variable_sensitivities.size());
-    EXPECT_EQ(1, positive_mutable_variable_sensitivities.size());
+    EXPECT_EQ(3, static_cast<int>(mutable_variable_sensitivities.size()));
+    EXPECT_EQ(1,
+              static_cast<int>(positive_mutable_variable_sensitivities.size()));
     EXPECT_TRUE(positive_mutable_variable_sensitivities.find(&variable_0) !=
                 positive_mutable_variable_sensitivities.end());
 
-    EXPECT_EQ(2, negative_mutable_variable_sensitivities.size());
+    EXPECT_EQ(2,
+              static_cast<int>(negative_mutable_variable_sensitivities.size()));
     EXPECT_TRUE(negative_mutable_variable_sensitivities.find(&variable_1) !=
                 negative_mutable_variable_sensitivities.end());
     EXPECT_TRUE(negative_mutable_variable_sensitivities.find(&variable_2) !=

--- a/test/model/test_expression.cpp
+++ b/test/model/test_expression.cpp
@@ -298,6 +298,24 @@ TEST_F(TestExpression, disable) {
 }
 
 /*****************************************************************************/
+TEST_F(TestExpression, erase) {
+    auto expression =
+        printemps::model::Expression<int, double>::create_instance();
+
+    auto variable_0 =
+        printemps::model::Variable<int, double>::create_instance();
+    auto variable_1 =
+        printemps::model::Variable<int, double>::create_instance();
+
+    expression = variable_0 + 2 * variable_1 + 4;
+    expression.erase(&variable_0);
+
+    EXPECT_EQ(2, expression.sensitivities().at(&variable_1));
+    EXPECT_TRUE(expression.sensitivities().find(&variable_0) ==
+                expression.sensitivities().end());
+}
+
+/*****************************************************************************/
 TEST_F(TestExpression, substitute) {
     auto expression_0 =
         printemps::model::Expression<int, double>::create_instance();
@@ -317,6 +335,93 @@ TEST_F(TestExpression, substitute) {
     EXPECT_EQ(18, expression_0.constant_value());
     EXPECT_TRUE(expression_0.sensitivities().find(&variable_1) ==
                 expression_0.sensitivities().end());
+}
+
+/*****************************************************************************/
+TEST_F(TestExpression, lower_bound) {
+    auto expression =
+        printemps::model::Expression<int, double>::create_instance();
+
+    auto variable_0 =
+        printemps::model::Variable<int, double>::create_instance();
+    auto variable_1 =
+        printemps::model::Variable<int, double>::create_instance();
+    auto variable_2 =
+        printemps::model::Variable<int, double>::create_instance();
+
+    variable_0.set_bound(-10, 20);
+    variable_1.set_bound(-100, 200);
+    variable_2.fix_by(30);
+    expression = variable_0 - 2 * variable_1 + variable_2 + 4;
+
+    EXPECT_EQ(-376, expression.lower_bound());
+    EXPECT_EQ(254, expression.upper_bound());
+    EXPECT_EQ(30, expression.fixed_term_value());
+}
+
+/*****************************************************************************/
+TEST_F(TestExpression, upper_bound) {
+    /// This method is tested in lower_bound().
+}
+
+/*****************************************************************************/
+TEST_F(TestExpression, fixed_term_value) {
+    /// This method is tested in lower_bound().
+}
+
+/*****************************************************************************/
+TEST_F(TestExpression, mutable_variable_sensitivities) {
+    auto expression =
+        printemps::model::Expression<int, double>::create_instance();
+
+    auto variable_0 =
+        printemps::model::Variable<int, double>::create_instance();
+    auto variable_1 =
+        printemps::model::Variable<int, double>::create_instance();
+    auto variable_2 =
+        printemps::model::Variable<int, double>::create_instance();
+    auto variable_3 =
+        printemps::model::Variable<int, double>::create_instance();
+    auto variable_4 =
+        printemps::model::Variable<int, double>::create_instance();
+    auto variable_5 =
+        printemps::model::Variable<int, double>::create_instance();
+
+    expression = variable_0 - variable_1 - variable_2 + variable_3 +
+                 variable_4 + variable_5;
+    variable_3.fix_by(1);
+    variable_4.fix_by(1);
+    variable_5.fix_by(1);
+
+    auto mutable_variable_sensitivities =
+        expression.mutable_variable_sensitivities();
+
+    auto positive_mutable_variable_sensitivities =
+        expression.positive_mutable_variable_sensitivities();
+
+    auto negative_mutable_variable_sensitivities =
+        expression.negative_mutable_variable_sensitivities();
+
+    EXPECT_EQ(3, mutable_variable_sensitivities.size());
+    EXPECT_EQ(1, positive_mutable_variable_sensitivities.size());
+    EXPECT_TRUE(positive_mutable_variable_sensitivities.find(&variable_0) !=
+                positive_mutable_variable_sensitivities.end());
+
+    EXPECT_EQ(2, negative_mutable_variable_sensitivities.size());
+    EXPECT_TRUE(negative_mutable_variable_sensitivities.find(&variable_1) !=
+                negative_mutable_variable_sensitivities.end());
+    EXPECT_TRUE(negative_mutable_variable_sensitivities.find(&variable_2) !=
+                negative_mutable_variable_sensitivities.end());
+}
+
+/*****************************************************************************/
+TEST_F(TestExpression, positive_mutable_variable_sensitivities) {
+    /// This method is tested in mutable_variable_sensitivities().
+}
+
+/*****************************************************************************/
+TEST_F(TestExpression, negative_mutable_variable_sensitivities) {
+    /// This method is tested in mutable_variable_sensitivities().
 }
 
 /*****************************************************************************/

--- a/test/model/test_model.cpp
+++ b/test/model/test_model.cpp
@@ -945,6 +945,7 @@ TEST_F(TestModel, setup_variable_related_constraints) {
 
     model.categorize_constraints();
     model.setup_variable_related_constraints();
+    model.setup_variable_related_zero_one_coefficient_constraints();
 
     for (auto i = 0; i < 10; i++) {
         EXPECT_TRUE(x(i).related_constraint_ptrs().find(&g(0)) !=
@@ -996,6 +997,11 @@ TEST_F(TestModel, setup_variable_related_constraints) {
     EXPECT_FALSE(
         x(0).related_zero_one_coefficient_constraint_ptrs().find(&g(2)) !=
         x(0).related_zero_one_coefficient_constraint_ptrs().end());
+}
+
+/*****************************************************************************/
+TEST_F(TestModel, setup_variable_related_zero_one_coefficient_constraints) {
+    /// This method is tested in setup_variable_related_constraints().
 }
 
 /*****************************************************************************/

--- a/test/neighborhood/test_move.cpp
+++ b/test/neighborhood/test_move.cpp
@@ -192,6 +192,7 @@ TEST_F(TestMove, compute_overlap_rate) {
 
     model.categorize_constraints();
     model.setup_variable_related_constraints();
+    model.setup_variable_related_zero_one_coefficient_constraints();
 
     /// x(0) and x(1) have two common constraints.
     {

--- a/test/presolver/test_intermediate_variable_extractor.cpp
+++ b/test/presolver/test_intermediate_variable_extractor.cpp
@@ -151,7 +151,7 @@ TEST_F(TestIntermediateVariableExtractor, extract_intermediate_variables) {
             printemps::presolver::
                 extract_independent_intermediate_variables(  //
                     &model,                                  //
-                    true);
+                    false);
 
             model.categorize_variables();
             model.categorize_constraints();

--- a/test/presolver/test_intermediate_variable_extractor.cpp
+++ b/test/presolver/test_intermediate_variable_extractor.cpp
@@ -144,14 +144,14 @@ TEST_F(TestIntermediateVariableExtractor, extract_intermediate_variables) {
         model.setup_variable_sensitivity();
 
         EXPECT_TRUE(f(0).is_intermediate());
-        EXPECT_FALSE(g(0).is_intermediate());
+        EXPECT_TRUE(g(0).is_intermediate());
 
         /// Extracting (Round 1)
         {
             printemps::presolver::
                 extract_independent_intermediate_variables(  //
                     &model,                                  //
-                    false);
+                    true);
 
             model.categorize_variables();
             model.categorize_constraints();
@@ -162,13 +162,35 @@ TEST_F(TestIntermediateVariableExtractor, extract_intermediate_variables) {
                       z(0).sense());
             EXPECT_FALSE(f.is_enabled());
 
-            /**
-             * The decision variable w will not be extracted as intermediate
-             * variable because the range of w is narrower than that of z.
-             */
+            EXPECT_EQ(printemps::model::VariableSense::Intermediate,
+                      w(0).sense());
+            EXPECT_FALSE(g.is_enabled());
 
-            EXPECT_EQ(printemps::model::VariableSense::Integer, w(0).sense());
-            EXPECT_TRUE(g.is_enabled());
+            auto& constraint_proxies = model.constraint_proxies();
+            EXPECT_EQ(3, static_cast<int>(constraint_proxies.size()));
+            EXPECT_EQ(2, static_cast<int>(constraint_proxies.back()
+                                              .flat_indexed_constraints()
+                                              .size()));
+            {
+                auto& additional_sensitivities =
+                    constraint_proxies.back()
+                        .flat_indexed_constraints(0)
+                        .expression()
+                        .sensitivities();
+                EXPECT_EQ(3, additional_sensitivities.at(&x(0)));
+                EXPECT_EQ(4, additional_sensitivities.at(&y(0)));
+                EXPECT_EQ(5, additional_sensitivities.at(&z(0)));
+            }
+            {
+                auto& additional_sensitivities =
+                    constraint_proxies.back()
+                        .flat_indexed_constraints(1)
+                        .expression()
+                        .sensitivities();
+                EXPECT_EQ(3, additional_sensitivities.at(&x(0)));
+                EXPECT_EQ(4, additional_sensitivities.at(&y(0)));
+                EXPECT_EQ(5, additional_sensitivities.at(&z(0)));
+            }
         }
 
         /// Eliminating (Round 1-1)
@@ -186,81 +208,34 @@ TEST_F(TestIntermediateVariableExtractor, extract_intermediate_variables) {
             auto& sensitivities_objective =
                 model.objective().expression().sensitivities();
 
-            EXPECT_EQ(1, sensitivities_objective.at(&w(0)));
+            EXPECT_EQ(3, sensitivities_objective.at(&x(0)));
+            EXPECT_EQ(4, sensitivities_objective.at(&y(0)));
+            EXPECT_EQ(5, sensitivities_objective.at(&z(0)));
 
             auto& sensitivities_g = g(0).expression().sensitivities();
 
             EXPECT_EQ(-13, sensitivities_g.at(&x(0)));
             EXPECT_EQ(-9, sensitivities_g.at(&y(0)));
-        }
 
-        /// Eliminating (Round 1-2)
-        {
-            /// Same result as round 1-2 should be obtained.
-            printemps::presolver::
-                eliminate_independent_intermediate_variables(  //
-                    &model,                                    //
-                    false);
-
-            model.categorize_variables();
-            model.categorize_constraints();
-            model.setup_variable_related_constraints();
-            model.setup_variable_sensitivity();
-
-            auto& sensitivities_objective =
-                model.objective().expression().sensitivities();
-
-            EXPECT_EQ(1, sensitivities_objective.at(&w(0)));
-
-            auto& sensitivities_g = g(0).expression().sensitivities();
-
-            EXPECT_EQ(-13, sensitivities_g.at(&x(0)));
-            EXPECT_EQ(-9, sensitivities_g.at(&y(0)));
-        }
-
-        /// Extracting (Round 2)
-        {
-            printemps::presolver::
-                extract_independent_intermediate_variables(  //
-                    &model,                                  //
-                    false);
-
-            model.categorize_variables();
-            model.categorize_constraints();
-            model.setup_variable_related_constraints();
-            model.setup_variable_sensitivity();
-
-            EXPECT_EQ(printemps::model::VariableSense::Intermediate,
-                      z(0).sense());
-            EXPECT_FALSE(f.is_enabled());
-
-            EXPECT_EQ(printemps::model::VariableSense::Intermediate,
-                      w(0).sense());
-            EXPECT_FALSE(g.is_enabled());
-        }
-
-        /// Eliminating (Round 2-1)
-        {
-            printemps::presolver::
-                eliminate_independent_intermediate_variables(  //
-                    &model,                                    //
-                    false);
-
-            model.categorize_variables();
-            model.categorize_constraints();
-            model.setup_variable_related_constraints();
-            model.setup_variable_sensitivity();
-
-            auto& sensitivities_objective =
-                model.objective().expression().sensitivities();
-
-            EXPECT_EQ(13, sensitivities_objective.at(&x(0)));
-            EXPECT_EQ(9, sensitivities_objective.at(&y(0)));
-
-            auto& sensitivities_g = g(0).expression().sensitivities();
-
-            EXPECT_EQ(-13, sensitivities_g.at(&x(0)));
-            EXPECT_EQ(-9, sensitivities_g.at(&y(0)));
+            auto& constraint_proxies = model.constraint_proxies();
+            {
+                auto& additional_sensitivities =
+                    constraint_proxies.back()
+                        .flat_indexed_constraints(0)
+                        .expression()
+                        .sensitivities();
+                EXPECT_EQ(13, additional_sensitivities.at(&x(0)));
+                EXPECT_EQ(9, additional_sensitivities.at(&y(0)));
+            }
+            {
+                auto& additional_sensitivities =
+                    constraint_proxies.back()
+                        .flat_indexed_constraints(1)
+                        .expression()
+                        .sensitivities();
+                EXPECT_EQ(13, additional_sensitivities.at(&x(0)));
+                EXPECT_EQ(9, additional_sensitivities.at(&y(0)));
+            }
         }
     }
 }

--- a/test/presolver/test_presolver.cpp
+++ b/test/presolver/test_presolver.cpp
@@ -63,6 +63,7 @@ TEST_F(TestPresolver, remove_independent_variables) {
 
         auto& x = model.create_variables("x", 10, 0, 1);
         model.minimize(x.sum());
+        model.setup_variable_sensitivity();
 
         printemps::presolver::remove_independent_variables(&model, false);
 
@@ -76,6 +77,7 @@ TEST_F(TestPresolver, remove_independent_variables) {
 
         auto& x = model.create_variables("x", 10, 0, 1);
         model.maximize(x.sum());
+        model.setup_variable_sensitivity();
 
         printemps::presolver::remove_independent_variables(&model, false);
         for (auto i = 0; i < 10; i++) {
@@ -88,6 +90,7 @@ TEST_F(TestPresolver, remove_independent_variables) {
 
         auto& x = model.create_variables("x", 10, 0, 1);
         model.minimize(-x.sum());
+        model.setup_variable_sensitivity();
 
         printemps::presolver::remove_independent_variables(&model, false);
         for (auto i = 0; i < 10; i++) {
@@ -100,6 +103,7 @@ TEST_F(TestPresolver, remove_independent_variables) {
 
         auto& x = model.create_variables("x", 10, 0, 1);
         model.maximize(-x.sum());
+        model.setup_variable_sensitivity();
 
         printemps::presolver::remove_independent_variables(&model, false);
         for (auto i = 0; i < 10; i++) {


### PR DESCRIPTION
This PR improves the presolving algorithm to detect and eliminate intermediate variables. Now, a constraint such that `X = a^{T}x + b` will be eliminated and range constraints `l <= a^{T}x + b <= u` will be added, where `l` and `u` respectively denote the lower and upper bounds of `X`.

This PR includes the following commits: