### PR TITLE
Feature std17

### DIFF
--- a/cmake/application/CMakeLists.txt
+++ b/cmake/application/CMakeLists.txt
@@ -25,7 +25,7 @@ if(${CMAKE_BUILD_TYPE} STREQUAL "Release")
     )
 else() # Debug
     add_compile_options(
-        -std=c++17
+        -std=c++14
         -Wall
         -Wextra
         -Wno-error=missing-field-initializers

--- a/printemps/model_component/constraint_binary_operator.h
+++ b/printemps/model_component/constraint_binary_operator.h
@@ -37,9 +37,11 @@ namespace model_component {
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value,
           template <class, class> class T_ExpressionLike>
-constexpr Constraint<T_Variable, T_Expression> operator<=(
+constexpr auto operator<=(
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE,
-    const T_Value                                     a_TARGET) {
+    const T_Value                                     a_TARGET)
+    -> decltype(a_EXPRESSION_LIKE.to_expression() - a_TARGET,
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION_LIKE.to_expression() - a_TARGET, ConstraintSense::Less);
 }
@@ -47,27 +49,33 @@ constexpr Constraint<T_Variable, T_Expression> operator<=(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value,
           template <class, class> class T_ExpressionLike>
-constexpr Constraint<T_Variable, T_Expression> operator<=(
+constexpr auto operator<=(
     const T_Value                                     a_TARGET,
-    const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE) {
+    const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE)
+    -> decltype(-a_EXPRESSION_LIKE.to_expression() + a_TARGET,
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         -a_EXPRESSION_LIKE.to_expression() + a_TARGET, ConstraintSense::Less);
 }
 
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value>
-constexpr Constraint<T_Variable, T_Expression> operator<=(
+constexpr auto operator<=(
     const Expression<T_Variable, T_Expression> &a_EXPRESSION,
-    const T_Value                               a_TARGET) {
+    const T_Value                               a_TARGET)
+    -> decltype(a_EXPRESSION.self() - a_TARGET,
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION.self() - a_TARGET, ConstraintSense::Less);
 }
 
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value>
-constexpr Constraint<T_Variable, T_Expression> operator<=(
+constexpr auto operator<=(
     const T_Value                               a_TARGET,
-    const Expression<T_Variable, T_Expression> &a_EXPRESSION) {
+    const Expression<T_Variable, T_Expression> &a_EXPRESSION)
+    -> decltype(-a_EXPRESSION.self() + a_TARGET,
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         -a_EXPRESSION.self() + a_TARGET, ConstraintSense::Less);
 }
@@ -75,9 +83,11 @@ constexpr Constraint<T_Variable, T_Expression> operator<=(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression,
           template <class, class> class T_ExpressionLike>
-constexpr Constraint<T_Variable, T_Expression> operator<=(
+constexpr auto operator<=(
     const Expression<T_Variable, T_Expression> &      a_EXPRESSION,
-    const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE) {
+    const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE)
+    -> decltype(a_EXPRESSION.self() - a_EXPRESSION_LIKE.to_expression(),
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION.self() - a_EXPRESSION_LIKE.to_expression(),
         ConstraintSense::Less);
@@ -86,9 +96,11 @@ constexpr Constraint<T_Variable, T_Expression> operator<=(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression,
           template <class, class> class T_ExpressionLike>
-constexpr Constraint<T_Variable, T_Expression> operator<=(
+constexpr auto operator<=(
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE,
-    const Expression<T_Variable, T_Expression> &      a_EXPRESSION) {
+    const Expression<T_Variable, T_Expression> &      a_EXPRESSION)
+    -> decltype(a_EXPRESSION_LIKE.to_expression() - a_EXPRESSION.self(),
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION_LIKE.to_expression() - a_EXPRESSION.self(),
         ConstraintSense::Less);
@@ -98,11 +110,13 @@ constexpr Constraint<T_Variable, T_Expression> operator<=(
 template <class T_Variable, class T_Expression,
           template <class, class> class T_ExpressionLikeLeft,
           template <class, class> class T_ExpressionLikeRight>
-constexpr Constraint<T_Variable, T_Expression> operator<=(
-    const T_ExpressionLikeLeft<T_Variable, T_Expression>
-        &a_EXPRESSION_LIKE_LEFT,
-    const T_ExpressionLikeRight<T_Variable, T_Expression>
-        &a_EXPRESSION_LIKE_RIGHT) {
+constexpr auto operator<=(const T_ExpressionLikeLeft<T_Variable, T_Expression>
+                              &a_EXPRESSION_LIKE_LEFT,
+                          const T_ExpressionLikeRight<T_Variable, T_Expression>
+                              &a_EXPRESSION_LIKE_RIGHT)
+    -> decltype(a_EXPRESSION_LIKE_LEFT.to_expression() -
+                    a_EXPRESSION_LIKE_RIGHT.to_expression(),
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION_LIKE_LEFT.to_expression() -
             a_EXPRESSION_LIKE_RIGHT.to_expression(),
@@ -111,9 +125,11 @@ constexpr Constraint<T_Variable, T_Expression> operator<=(
 
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
-constexpr Constraint<T_Variable, T_Expression> operator<=(
+constexpr auto operator<=(
     const Expression<T_Variable, T_Expression> &a_EXPRESSION_LEFT,
-    const Expression<T_Variable, T_Expression> &a_EXPRESSION_RIGHT) {
+    const Expression<T_Variable, T_Expression> &a_EXPRESSION_RIGHT)
+    -> decltype(a_EXPRESSION_LEFT.self() - a_EXPRESSION_RIGHT.self(),
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION_LEFT.self() - a_EXPRESSION_RIGHT.self(),
         ConstraintSense::Less);
@@ -124,9 +140,11 @@ constexpr Constraint<T_Variable, T_Expression> operator<=(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value,
           template <class, class> class T_ExpressionLike>
-constexpr Constraint<T_Variable, T_Expression> operator==(
+constexpr auto operator==(
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE,
-    const T_Value                                     a_TARGET) {
+    const T_Value                                     a_TARGET)
+    -> decltype(a_EXPRESSION_LIKE.to_expression() - a_TARGET,
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION_LIKE.to_expression() - a_TARGET, ConstraintSense::Equal);
 }
@@ -134,27 +152,33 @@ constexpr Constraint<T_Variable, T_Expression> operator==(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value,
           template <class, class> class T_ExpressionLike>
-constexpr Constraint<T_Variable, T_Expression> operator==(
+constexpr auto operator==(
     const T_Value                                     a_TARGET,
-    const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE) {
+    const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE)
+    -> decltype(-a_EXPRESSION_LIKE.to_expression() + a_TARGET,
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         -a_EXPRESSION_LIKE.to_expression() + a_TARGET, ConstraintSense::Equal);
 }
 
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value>
-constexpr Constraint<T_Variable, T_Expression> operator==(
+constexpr auto operator==(
     const Expression<T_Variable, T_Expression> &a_EXPRESSION,
-    const T_Value                               a_TARGET) {
+    const T_Value                               a_TARGET)
+    -> decltype(a_EXPRESSION.self() - a_TARGET,
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION.self() - a_TARGET, ConstraintSense::Equal);
 }
 
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value>
-constexpr Constraint<T_Variable, T_Expression> operator==(
+constexpr auto operator==(
     const T_Value                               a_TARGET,
-    const Expression<T_Variable, T_Expression> &a_EXPRESSION) {
+    const Expression<T_Variable, T_Expression> &a_EXPRESSION)
+    -> decltype(-a_EXPRESSION.self() + a_TARGET,
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         -a_EXPRESSION.self() + a_TARGET, ConstraintSense::Equal);
 }
@@ -162,9 +186,11 @@ constexpr Constraint<T_Variable, T_Expression> operator==(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression,
           template <class, class> class T_ExpressionLike>
-constexpr Constraint<T_Variable, T_Expression> operator==(
+constexpr auto operator==(
     const Expression<T_Variable, T_Expression> &      a_EXPRESSION,
-    const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE) {
+    const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE)
+    -> decltype(a_EXPRESSION.self() - a_EXPRESSION_LIKE.to_expression(),
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION.self() - a_EXPRESSION_LIKE.to_expression(),
         ConstraintSense::Equal);
@@ -173,9 +199,11 @@ constexpr Constraint<T_Variable, T_Expression> operator==(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression,
           template <class, class> class T_ExpressionLike>
-constexpr Constraint<T_Variable, T_Expression> operator==(
+constexpr auto operator==(
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE,
-    const Expression<T_Variable, T_Expression> &      a_EXPRESSION) {
+    const Expression<T_Variable, T_Expression> &      a_EXPRESSION)
+    -> decltype(a_EXPRESSION_LIKE.to_expression() - a_EXPRESSION.self(),
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION_LIKE.to_expression() - a_EXPRESSION.self(),
         ConstraintSense::Equal);
@@ -185,11 +213,13 @@ constexpr Constraint<T_Variable, T_Expression> operator==(
 template <class T_Variable, class T_Expression,
           template <class, class> class T_ExpressionLikeLeft,
           template <class, class> class T_ExpressionLikeRight>
-constexpr Constraint<T_Variable, T_Expression> operator==(
-    const T_ExpressionLikeLeft<T_Variable, T_Expression>
-        &a_EXPRESSION_LIKE_LEFT,
-    const T_ExpressionLikeRight<T_Variable, T_Expression>
-        &a_EXPRESSION_LIKE_RIGHT) {
+constexpr auto operator==(const T_ExpressionLikeLeft<T_Variable, T_Expression>
+                              &a_EXPRESSION_LIKE_LEFT,
+                          const T_ExpressionLikeRight<T_Variable, T_Expression>
+                              &a_EXPRESSION_LIKE_RIGHT)
+    -> decltype(a_EXPRESSION_LIKE_LEFT.to_expression() -
+                    a_EXPRESSION_LIKE_RIGHT.to_expression(),
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION_LIKE_LEFT.to_expression() -
             a_EXPRESSION_LIKE_RIGHT.to_expression(),
@@ -198,9 +228,11 @@ constexpr Constraint<T_Variable, T_Expression> operator==(
 
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
-constexpr Constraint<T_Variable, T_Expression> operator==(
+constexpr auto operator==(
     const Expression<T_Variable, T_Expression> &a_EXPRESSION_LEFT,
-    const Expression<T_Variable, T_Expression> &a_EXPRESSION_RIGHT) {
+    const Expression<T_Variable, T_Expression> &a_EXPRESSION_RIGHT)
+    -> decltype(a_EXPRESSION_LEFT.self() - a_EXPRESSION_RIGHT.self(),
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION_LEFT.self() - a_EXPRESSION_RIGHT.self(),
         ConstraintSense::Equal);
@@ -211,9 +243,11 @@ constexpr Constraint<T_Variable, T_Expression> operator==(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value,
           template <class, class> class T_ExpressionLike>
-constexpr Constraint<T_Variable, T_Expression> operator>=(
+constexpr auto operator>=(
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE,
-    const T_Value                                     a_TARGET) {
+    const T_Value                                     a_TARGET)
+    -> decltype(a_EXPRESSION_LIKE.to_expression() - a_TARGET,
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION_LIKE.to_expression() - a_TARGET, ConstraintSense::Greater);
 }
@@ -221,9 +255,11 @@ constexpr Constraint<T_Variable, T_Expression> operator>=(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value,
           template <class, class> class T_ExpressionLike>
-constexpr Constraint<T_Variable, T_Expression> operator>=(
+constexpr auto operator>=(
     const T_Value                                     a_TARGET,
-    const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE) {
+    const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE)
+    -> decltype(-a_EXPRESSION_LIKE.to_expression() + a_TARGET,
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         -a_EXPRESSION_LIKE.to_expression() + a_TARGET,
         ConstraintSense::Greater);
@@ -231,18 +267,22 @@ constexpr Constraint<T_Variable, T_Expression> operator>=(
 
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value>
-constexpr Constraint<T_Variable, T_Expression> operator>=(
+constexpr auto operator>=(
     const Expression<T_Variable, T_Expression> &a_EXPRESSION,
-    const T_Value                               a_TARGET) {
+    const T_Value                               a_TARGET)
+    -> decltype(a_EXPRESSION.self() - a_TARGET,
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION.self() - a_TARGET, ConstraintSense::Greater);
 }
 
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value>
-constexpr Constraint<T_Variable, T_Expression> operator>=(
+constexpr auto operator>=(
     const T_Value                               a_TARGET,
-    const Expression<T_Variable, T_Expression> &a_EXPRESSION) {
+    const Expression<T_Variable, T_Expression> &a_EXPRESSION)
+    -> decltype(-a_EXPRESSION.self() + a_TARGET,
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         -a_EXPRESSION.self() + a_TARGET, ConstraintSense::Greater);
 }
@@ -250,9 +290,11 @@ constexpr Constraint<T_Variable, T_Expression> operator>=(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression,
           template <class, class> class T_ExpressionLike>
-constexpr Constraint<T_Variable, T_Expression> operator>=(
+constexpr auto operator>=(
     const Expression<T_Variable, T_Expression> &      a_EXPRESSION,
-    const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE) {
+    const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE)
+    -> decltype(a_EXPRESSION.self() - a_EXPRESSION_LIKE.to_expression(),
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION.self() - a_EXPRESSION_LIKE.to_expression(),
         ConstraintSense::Greater);
@@ -261,9 +303,11 @@ constexpr Constraint<T_Variable, T_Expression> operator>=(
 /*****************************************************************************/
 template <class T_Variable, class T_Expression,
           template <class, class> class T_ExpressionLike>
-constexpr Constraint<T_Variable, T_Expression> operator>=(
+constexpr auto operator>=(
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE,
-    const Expression<T_Variable, T_Expression> &      a_EXPRESSION) {
+    const Expression<T_Variable, T_Expression> &      a_EXPRESSION)
+    -> decltype(a_EXPRESSION_LIKE.to_expression() - a_EXPRESSION.self(),
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION_LIKE.to_expression() - a_EXPRESSION.self(),
         ConstraintSense::Greater);
@@ -273,11 +317,13 @@ constexpr Constraint<T_Variable, T_Expression> operator>=(
 template <class T_Variable, class T_Expression,
           template <class, class> class T_ExpressionLikeLeft,
           template <class, class> class T_ExpressionLikeRight>
-constexpr Constraint<T_Variable, T_Expression> operator>=(
-    const T_ExpressionLikeLeft<T_Variable, T_Expression>
-        &a_EXPRESSION_LIKE_LEFT,
-    const T_ExpressionLikeRight<T_Variable, T_Expression>
-        &a_EXPRESSION_LIKE_RIGHT) {
+constexpr auto operator>=(const T_ExpressionLikeLeft<T_Variable, T_Expression>
+                              &a_EXPRESSION_LIKE_LEFT,
+                          const T_ExpressionLikeRight<T_Variable, T_Expression>
+                              &a_EXPRESSION_LIKE_RIGHT)
+    -> decltype(a_EXPRESSION_LIKE_LEFT.to_expression() -
+                    a_EXPRESSION_LIKE_RIGHT.to_expression(),
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION_LIKE_LEFT.to_expression() -
             a_EXPRESSION_LIKE_RIGHT.to_expression(),
@@ -286,9 +332,11 @@ constexpr Constraint<T_Variable, T_Expression> operator>=(
 
 /*****************************************************************************/
 template <class T_Variable, class T_Expression>
-constexpr Constraint<T_Variable, T_Expression> operator>=(
+constexpr auto operator>=(
     const Expression<T_Variable, T_Expression> &a_EXPRESSION_LEFT,
-    const Expression<T_Variable, T_Expression> &a_EXPRESSION_RIGHT) {
+    const Expression<T_Variable, T_Expression> &a_EXPRESSION_RIGHT)
+    -> decltype(a_EXPRESSION_LEFT.self() - a_EXPRESSION_RIGHT.self(),
+                model_component::Constraint<T_Variable, T_Expression>()) {
     return Constraint<T_Variable, T_Expression>::create_instance(
         a_EXPRESSION_LEFT.self() - a_EXPRESSION_RIGHT.self(),
         ConstraintSense::Greater);

--- a/printemps/model_component/expression_binary_operator.h
+++ b/printemps/model_component/expression_binary_operator.h
@@ -24,7 +24,7 @@ template <class T_Variable, class T_Expression, class T_Value,
 constexpr auto operator+(
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE,
     const T_Value                                     a_VALUE)  //
-    -> decltype(a_EXPRESSION_LIKE.to_expression()) {
+    -> decltype(a_EXPRESSION_LIKE.to_expression() + a_VALUE) {
     return a_EXPRESSION_LIKE.to_expression() + a_VALUE;
 }
 
@@ -34,7 +34,7 @@ template <class T_Variable, class T_Expression, class T_Value,
 constexpr auto operator+(
     const T_Value                                     a_VALUE,
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE)
-    -> decltype(a_EXPRESSION_LIKE.to_expression()) {
+    -> decltype(a_VALUE + a_EXPRESSION_LIKE.to_expression()) {
     return a_VALUE + a_EXPRESSION_LIKE.to_expression();
 }
 
@@ -46,7 +46,8 @@ constexpr auto operator+(const T_ExpressionLikeLeft<T_Variable, T_Expression>
                              &a_EXPRESSION_LIKE_LEFT,
                          const T_ExpressionLikeRight<T_Variable, T_Expression>
                              &a_EXPRESSION_LIKE_RIGHT)
-    -> decltype(a_EXPRESSION_LIKE_LEFT.to_expression()) {
+    -> decltype(a_EXPRESSION_LIKE_LEFT.to_expression() +
+                a_EXPRESSION_LIKE_RIGHT.to_expression()) {
     return a_EXPRESSION_LIKE_LEFT.to_expression() +
            a_EXPRESSION_LIKE_RIGHT.to_expression();
 }
@@ -57,7 +58,7 @@ template <class T_Variable, class T_Expression, class T_Value,
 auto operator-(
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE,
     const T_Value                                     a_VALUE)  //
-    -> decltype(a_EXPRESSION_LIKE.to_expression()) {
+    -> decltype(a_EXPRESSION_LIKE.to_expression() - a_VALUE) {
     return a_EXPRESSION_LIKE.to_expression() - a_VALUE;
 }
 
@@ -67,7 +68,7 @@ template <class T_Variable, class T_Expression, class T_Value,
 constexpr auto operator-(
     const T_Value                                     a_VALUE,
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE)
-    -> decltype(a_EXPRESSION_LIKE.to_expression()) {
+    -> decltype(a_VALUE - a_EXPRESSION_LIKE.to_expression()) {
     return a_VALUE - a_EXPRESSION_LIKE.to_expression();
 }
 
@@ -79,7 +80,8 @@ constexpr auto operator-(const T_ExpressionLikeLeft<T_Variable, T_Expression>
                              &a_EXPRESSION_LIKE_LEFT,
                          const T_ExpressionLikeRight<T_Variable, T_Expression>
                              &a_EXPRESSION_LIKE_RIGHT)
-    -> decltype(a_EXPRESSION_LIKE_LEFT.to_expression()) {
+    -> decltype(a_EXPRESSION_LIKE_LEFT.to_expression() -
+                a_EXPRESSION_LIKE_RIGHT.to_expression()) {
     return a_EXPRESSION_LIKE_LEFT.to_expression() -
            a_EXPRESSION_LIKE_RIGHT.to_expression();
 }
@@ -90,7 +92,7 @@ template <class T_Variable, class T_Expression, class T_Value,
 auto operator*(
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE,
     const T_Value                                     a_VALUE)  //
-    -> decltype(a_EXPRESSION_LIKE.to_expression()) {
+    -> decltype(a_EXPRESSION_LIKE.to_expression() * a_VALUE) {
     return a_EXPRESSION_LIKE.to_expression() * a_VALUE;
 }
 
@@ -100,7 +102,7 @@ template <class T_Variable, class T_Expression, class T_Value,
 auto operator*(
     const T_Value                                     a_VALUE,
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE)
-    -> decltype(a_EXPRESSION_LIKE.to_expression()) {
+    -> decltype(a_VALUE * a_EXPRESSION_LIKE.to_expression()) {
     return a_VALUE * a_EXPRESSION_LIKE.to_expression();
 }
 
@@ -110,7 +112,7 @@ template <class T_Variable, class T_Expression, class T_Value,
 constexpr auto operator/(
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE,
     const T_Value                                     a_VALUE)  //
-    -> decltype(a_EXPRESSION_LIKE.to_expression()) {
+    -> decltype(a_EXPRESSION_LIKE.to_expression() / a_VALUE) {
     return a_EXPRESSION_LIKE.to_expression() / a_VALUE;
 }
 
@@ -122,7 +124,7 @@ template <class T_Variable, class T_Expression,
 constexpr auto operator+(
     const Expression<T_Variable, T_Expression> &      a_EXPRESSION,
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE)
-    -> decltype(a_EXPRESSION.copy()) {
+    -> decltype(a_EXPRESSION.copy() + a_EXPRESSION_LIKE.to_expression()) {
     return a_EXPRESSION.copy() + a_EXPRESSION_LIKE.to_expression();
 }
 
@@ -132,7 +134,7 @@ template <class T_Variable, class T_Expression,
 constexpr auto operator+(
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE,
     const Expression<T_Variable, T_Expression> &      a_EXPRESSION)
-    -> decltype(a_EXPRESSION.copy()) {
+    -> decltype(a_EXPRESSION_LIKE.to_expression() + a_EXPRESSION.copy()) {
     return a_EXPRESSION_LIKE.to_expression() + a_EXPRESSION.copy();
 }
 
@@ -142,7 +144,7 @@ template <class T_Variable, class T_Expression,
 constexpr auto operator-(
     const Expression<T_Variable, T_Expression> &      a_EXPRESSION,
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE)
-    -> decltype(a_EXPRESSION.copy()) {
+    -> decltype(a_EXPRESSION.copy() - a_EXPRESSION_LIKE.to_expression()) {
     return a_EXPRESSION.copy() - a_EXPRESSION_LIKE.to_expression();
 }
 
@@ -152,7 +154,7 @@ template <class T_Variable, class T_Expression,
 constexpr auto operator-(
     const T_ExpressionLike<T_Variable, T_Expression> &a_EXPRESSION_LIKE,
     const Expression<T_Variable, T_Expression> &      a_EXPRESSION)
-    -> decltype(a_EXPRESSION.copy()) {
+    -> decltype(a_EXPRESSION_LIKE.to_expression() - a_EXPRESSION.copy()) {
     return a_EXPRESSION_LIKE.to_expression() - a_EXPRESSION.copy();
 }
 
@@ -167,6 +169,7 @@ constexpr Expression<T_Variable, T_Expression> operator+(
     result += a_VALUE;
     return result;
 }
+
 /*****************************************************************************/
 template <class T_Variable, class T_Expression, class T_Value>
 constexpr Expression<T_Variable, T_Expression> operator+(

--- a/printemps/presolver/problem_size_reducer.h
+++ b/printemps/presolver/problem_size_reducer.h
@@ -21,7 +21,7 @@ constexpr bool remove_independent_variable(
         if (fabs(sensitivity) < constant::EPSILON_10) {
             utility::print_message(
                 "The value of decision variable " + a_variable_ptr->name() +
-                    " was fixed by " + std::to_string(0) +
+                    " was fixed as " + std::to_string(0) +
                     " because it does not have sensitivity to any constraint "
                     "or objective function.",
                 a_IS_ENABLED_PRINT);
@@ -34,7 +34,7 @@ constexpr bool remove_independent_variable(
                     utility::print_message(
                         "The value of decision variable " +
                             a_variable_ptr->name() +
-                            " was fixed by its lower bound " +
+                            " was fixed as its lower bound " +
                             std::to_string(fix_value) +
                             " because it does not have sensitivity to any "
                             "constraint, and the sensitivity to the objective "
@@ -47,7 +47,7 @@ constexpr bool remove_independent_variable(
                     utility::print_message(
                         "The value of decision variable " +
                             a_variable_ptr->name() +
-                            " was fixed by its upper bound " +
+                            " was fixed as its upper bound " +
                             std::to_string(fix_value) +
                             " because it does not have sensitivity to any "
                             "constraint, and the sensitivity to the objective "
@@ -62,7 +62,7 @@ constexpr bool remove_independent_variable(
                     utility::print_message(
                         "The value of decision variable " +
                             a_variable_ptr->name() +
-                            " was fixed by its upper bound " +
+                            " was fixed as its upper bound " +
                             std::to_string(fix_value) +
                             " because it does not have sensitivity to any "
                             "constraint, and the sensitivity to the objective "
@@ -75,7 +75,7 @@ constexpr bool remove_independent_variable(
                     utility::print_message(
                         "The value of decision variable " +
                             a_variable_ptr->name() +
-                            " was fixed by its lower bound " +
+                            " was fixed as its lower bound " +
                             std::to_string(fix_value) +
                             " because it does not have sensitivity to any "
                             "constraint, and the sensitivity to the objective "
@@ -105,7 +105,7 @@ constexpr bool fix_implicit_fixed_variable(
 
         utility::print_message(
             "The value of decision variable " + a_variable_ptr->name() +
-                " was fixed by " + std::to_string(fixed_value) +
+                " was fixed as " + std::to_string(fixed_value) +
                 " because the lower bound " + std::to_string(lower_bound) +
                 " and the upper_bound " + std::to_string(upper_bound) +
                 " implicitly fix the value.",
@@ -249,7 +249,7 @@ constexpr int fix_redundant_set_variables(
             }
 
             /**
-             * If x_{j} is fixed by 0, the following procedure can be skipped.
+             * If x_{j} is fixed as 0, the following procedure can be skipped.
              */
             if (variable_ptrs[j]->is_fixed() &&
                 variable_ptrs[j]->value() == 0) {
@@ -267,7 +267,7 @@ constexpr int fix_redundant_set_variables(
 
             /**
              * If x_{j} has superior objective coefficient than that of x_{i},
-             * the value of x_{i} will be fixed by 0 and break.
+             * the value of x_{i} will be fixed as 0 and break.
              */
             if ((a_model_ptr->is_minimization() &&
                  (variable_ptrs[i]->objective_sensitivity() >=
@@ -278,7 +278,7 @@ constexpr int fix_redundant_set_variables(
                 variable_ptrs[i]->fix_by(0);
                 utility::print_message(
                     "The value of redundant decision variable " +
-                        variable_ptrs[i]->name() + " was fixed by " +
+                        variable_ptrs[i]->name() + " was fixed as " +
                         std::to_string(0) + ".",
                     a_IS_ENABLED_PRINT);
 
@@ -288,7 +288,7 @@ constexpr int fix_redundant_set_variables(
             }
             /**
              * If x_{j} does not have superior objective coefficient than that
-             * of x_{i}, the value of x_{j} will be fixed by 0.
+             * of x_{i}, the value of x_{j} will be fixed as 0.
              */
             else if ((a_model_ptr->is_minimization() &&
                       (variable_ptrs[i]->objective_sensitivity() <
@@ -299,7 +299,7 @@ constexpr int fix_redundant_set_variables(
                 variable_ptrs[j]->fix_by(0);
                 utility::print_message(
                     "The value of redundant decision variable " +
-                        variable_ptrs[j]->name() + " was fixed by " +
+                        variable_ptrs[j]->name() + " was fixed as " +
                         std::to_string(0) + ".",
                     a_IS_ENABLED_PRINT);
 
@@ -384,7 +384,7 @@ constexpr bool remove_redundant_constraints_with_tightening_variable_bound(
             model_component::ConstraintSense::Equal) {
             /**
              * If the singleton constraint is defined by an equality as ax+b=0,
-             * the value of the decision variable x will be fixed by -b/a.
+             * the value of the decision variable x will be fixed as -b/a.
              */
             utility::print_message(  //
                 "The constraint " + a_constraint_ptr->name() +
@@ -658,7 +658,7 @@ constexpr std::pair<int, int> remove_redundant_set_constraints(
                                 variable_ptr->name() +
                                 " in partitioning constraint " +
                                 set_partitioning_ptrs[i]->name() +
-                                " was fixed by 0.",
+                                " was fixed as 0.",
                             a_IS_ENABLED_PRINT);
                         number_of_newly_fixed_variables++;
                     }

--- a/printemps/presolver/problem_size_reducer.h
+++ b/printemps/presolver/problem_size_reducer.h
@@ -203,26 +203,22 @@ constexpr int fix_redundant_set_variables(
     if (a_model_ptr->is_minimization()) {
         std::sort(variable_ptrs.begin(), variable_ptrs.end(),
                   [](const auto &a_LHS, const auto &a_RHS) {
-                      if (a_LHS->related_constraint_ptrs() ==
-                          a_RHS->related_constraint_ptrs()) {
-                          return a_LHS->objective_sensitivity() >
-                                 a_RHS->objective_sensitivity();
-                      } else {
-                          return a_LHS->related_constraint_ptrs().size() <
-                                 a_RHS->related_constraint_ptrs().size();
-                      }
+                      return (a_LHS->related_constraint_ptrs() ==
+                              a_RHS->related_constraint_ptrs())
+                                 ? (a_LHS->objective_sensitivity() >
+                                    a_RHS->objective_sensitivity())
+                                 : (a_LHS->related_constraint_ptrs().size() <
+                                    a_RHS->related_constraint_ptrs().size());
                   });
     } else {
         std::sort(variable_ptrs.begin(), variable_ptrs.end(),
                   [](const auto &a_LHS, const auto &a_RHS) {
-                      if (a_LHS->related_constraint_ptrs() ==
-                          a_RHS->related_constraint_ptrs()) {
-                          return a_LHS->objective_sensitivity() <
-                                 a_RHS->objective_sensitivity();
-                      } else {
-                          return a_LHS->related_constraint_ptrs().size() <
-                                 a_RHS->related_constraint_ptrs().size();
-                      }
+                      return (a_LHS->related_constraint_ptrs() ==
+                              a_RHS->related_constraint_ptrs())
+                                 ? (a_LHS->objective_sensitivity() <
+                                    a_RHS->objective_sensitivity())
+                                 : (a_LHS->related_constraint_ptrs().size() <
+                                    a_RHS->related_constraint_ptrs().size());
                   });
     }
 


### PR DESCRIPTION
This PR fixes compilation errors caused by gcc with -std=c++17, which come from ambiguous overloading for operator `==`.