### PR TITLE
Feature lagrangian penalty

### DIFF
--- a/application/printemps/utility/option_utility.h
+++ b/application/printemps/utility/option_utility.h
@@ -403,6 +403,12 @@ printemps::option::Option read_option(const std::string &a_FILE_NAME) {
                   option_object_tabu_search);
 
         /**********************************************************************/
+        /// tabu_search.lagrangian_penalty_coefficient
+        read_json(&option.tabu_search.lagrangian_penalty_coefficient,  //
+                  "lagrangian_penalty_coefficient",                    //
+                  option_object_tabu_search);
+
+        /**********************************************************************/
         /// tabu_search.pruning_rate_threshold
         read_json(&option.tabu_search.pruning_rate_threshold,  //
                   "pruning_rate_threshold",                    //

--- a/printemps/model/model.h
+++ b/printemps/model/model.h
@@ -1052,6 +1052,18 @@ class Model {
                         constraint_type_reference.invariant_knapsack_ptrs
                             .push_back(&constraint);
                     }
+                    if (constraint.is_multiple_cover()) {
+                        constraint_type_reference.multiple_cover_ptrs.push_back(
+                            &constraint);
+                    }
+                    if (constraint.is_binary_flow()) {
+                        constraint_type_reference.binary_flow_ptrs.push_back(
+                            &constraint);
+                    }
+                    if (constraint.is_integer_flow()) {
+                        constraint_type_reference.integer_flow_ptrs.push_back(
+                            &constraint);
+                    }
                     if (constraint.is_equation_knapsack()) {
                         constraint_type_reference.equation_knapsack_ptrs
                             .push_back(&constraint);
@@ -1465,6 +1477,48 @@ class Model {
                     utility::to_string(                         //
                         compute_number_of_enabled_constraints(  //
                             presolved.invariant_knapsack_ptrs),
+                        "%d") +
+                    ")",
+                true);
+
+            utility::print_info(                        //
+                " -- Multiple Cover: " +                //
+                    utility::to_string(                 //
+                        compute_number_of_constraints(  //
+                            original.multiple_cover_ptrs),
+                        "%d") +
+                    " (" +
+                    utility::to_string(                         //
+                        compute_number_of_enabled_constraints(  //
+                            presolved.multiple_cover_ptrs),
+                        "%d") +
+                    ")",
+                true);
+
+            utility::print_info(                        //
+                " -- Binary Flow: " +                   //
+                    utility::to_string(                 //
+                        compute_number_of_constraints(  //
+                            original.binary_flow_ptrs),
+                        "%d") +
+                    " (" +
+                    utility::to_string(                         //
+                        compute_number_of_enabled_constraints(  //
+                            presolved.binary_flow_ptrs),
+                        "%d") +
+                    ")",
+                true);
+
+            utility::print_info(                        //
+                " -- Integer Flow: " +                  //
+                    utility::to_string(                 //
+                        compute_number_of_constraints(  //
+                            original.integer_flow_ptrs),
+                        "%d") +
+                    " (" +
+                    utility::to_string(                         //
+                        compute_number_of_enabled_constraints(  //
+                            presolved.integer_flow_ptrs),
                         "%d") +
                     ")",
                 true);
@@ -1989,7 +2043,7 @@ class Model {
                 auto variable_ptr          = a_MOVE.alterations.front().first;
                 auto variable_value_target = a_MOVE.alterations.front().second;
 
-                if (constraint_ptr->is_binary()) {
+                if (constraint_ptr->has_only_binary_coefficient()) {
                     constraint_value = constraint_ptr->constraint_value() +
                                        variable_value_target -
                                        variable_ptr->value();
@@ -2852,7 +2906,7 @@ class Model {
     }
 
     /*************************************************************************/
-    inline constexpr bool has_zero_one_coefficient_constraints(void) const {
+    inline constexpr bool has_chain_move_effective_constraints(void) const {
         if (m_constraint_type_reference.set_partitioning_ptrs.size() > 0) {
             return true;
         }
@@ -2866,6 +2920,12 @@ class Model {
             return true;
         }
         if (m_constraint_type_reference.invariant_knapsack_ptrs.size() > 0) {
+            return true;
+        }
+        if (m_constraint_type_reference.multiple_cover_ptrs.size() > 0) {
+            return true;
+        }
+        if (m_constraint_type_reference.binary_flow_ptrs.size() > 0) {
             return true;
         }
         return false;

--- a/printemps/model_component/constraint.h
+++ b/printemps/model_component/constraint.h
@@ -70,7 +70,10 @@ class Constraint : public multi_array::AbstractMultiArrayElement {
     bool m_is_set_covering;
     bool m_is_cardinality;
     bool m_is_invariant_knapsack;
+    bool m_is_multiple_cover;
     bool m_is_equation_knapsack;
+    bool m_is_binary_flow;
+    bool m_is_integer_flow;
     bool m_is_bin_packing;
     bool m_is_knapsack;
     bool m_is_integer_knapsack;
@@ -79,7 +82,7 @@ class Constraint : public multi_array::AbstractMultiArrayElement {
     bool m_is_intermediate;
     bool m_is_gf2;
     bool m_is_general_linear;
-    bool m_is_binary;
+    bool m_has_only_binary_coefficient;
 
     bool m_has_aux_lower_bound;
     bool m_has_aux_upper_bound;
@@ -229,7 +232,10 @@ class Constraint : public multi_array::AbstractMultiArrayElement {
         m_is_set_covering       = false;
         m_is_cardinality        = false;
         m_is_invariant_knapsack = false;
+        m_is_multiple_cover     = false;
         m_is_equation_knapsack  = false;
+        m_is_binary_flow        = false;
+        m_is_integer_flow       = false;
         m_is_bin_packing        = false;
         m_is_knapsack           = false;
         m_is_integer_knapsack   = false;
@@ -239,7 +245,7 @@ class Constraint : public multi_array::AbstractMultiArrayElement {
         m_is_gf2                = false;
         m_is_general_linear     = false;
 
-        m_is_binary = false;
+        m_has_only_binary_coefficient = false;
 
         m_has_aux_lower_bound = false;
         m_has_aux_upper_bound = false;
@@ -383,22 +389,24 @@ class Constraint : public multi_array::AbstractMultiArrayElement {
         /// Aggregation (and Set Partitioning)
         if (m_expression.sensitivities().size() == 2 &&
             m_sense == ConstraintSense::Equal) {
-            m_is_aggregation = true;
-            bool is_binary   = true;
+            m_is_aggregation                 = true;
+            bool has_only_binary_coefficient = true;
             for (const auto &sensitivity : m_expression.sensitivities()) {
                 if ((sensitivity.first->sense() != VariableSense::Binary) &&
                     (sensitivity.first->sense() != VariableSense::Selection)) {
-                    is_binary = false;
+                    has_only_binary_coefficient = false;
                     break;
                 }
                 if (sensitivity.second != 1) {
-                    is_binary = false;
+                    has_only_binary_coefficient = false;
                     break;
                 }
             }
 
-            if (is_binary && m_expression.constant_value() == -1) {
-                m_is_set_partitioning = true;
+            if (has_only_binary_coefficient &&
+                m_expression.constant_value() == -1) {
+                m_has_only_binary_coefficient = true;
+                m_is_set_partitioning         = true;
             }
             return;
         }
@@ -436,20 +444,20 @@ class Constraint : public multi_array::AbstractMultiArrayElement {
         /// Set Partitioning or Set Packing, Set Covering, Cardinality,
         /// Invariant Knapsack.
         {
-            bool is_binary = true;
+            bool has_only_binary_coefficient = true;
             for (const auto &sensitivity : m_expression.sensitivities()) {
                 if ((sensitivity.first->sense() != VariableSense::Binary) &&
                     (sensitivity.first->sense() != VariableSense::Selection)) {
-                    is_binary = false;
+                    has_only_binary_coefficient = false;
                     break;
                 }
                 if (sensitivity.second != 1) {
-                    is_binary = false;
+                    has_only_binary_coefficient = false;
                     break;
                 }
             }
-            if (is_binary) {
-                m_is_binary = true;
+            if (has_only_binary_coefficient) {
+                m_has_only_binary_coefficient = true;
                 /// Set Partitioning
                 if (m_expression.constant_value() == -1 &&
                     m_sense == ConstraintSense::Equal) {
@@ -484,8 +492,45 @@ class Constraint : public multi_array::AbstractMultiArrayElement {
                     m_is_invariant_knapsack = true;
                     return;
                 }
+
+                /// Multiple Cover
+                if (m_expression.constant_value() <= -2 &&
+                    m_sense == ConstraintSense::Greater) {
+                    m_is_multiple_cover = true;
+                    return;
+                }
             } else {
-                m_is_binary = false;
+                m_has_only_binary_coefficient = false;
+            }
+        }
+
+        /// Binary Flow and Integer Flow
+        {
+            bool is_plus_or_minus_one_coefficient = true;
+            for (const auto &sensitivity : m_expression.sensitivities()) {
+                if (abs(sensitivity.second) != 1) {
+                    is_plus_or_minus_one_coefficient = false;
+                    break;
+                }
+            }
+
+            if (is_plus_or_minus_one_coefficient) {
+                bool has_only_binary_variables = true;
+                for (const auto &sensitivity : m_expression.sensitivities()) {
+                    if ((sensitivity.first->sense() != VariableSense::Binary) &&
+                        (sensitivity.first->sense() !=
+                         VariableSense::Selection)) {
+                        has_only_binary_variables = false;
+                        break;
+                    }
+                }
+                if (has_only_binary_variables) {
+                    m_is_binary_flow = true;
+                    return;
+                } else {
+                    m_is_integer_flow = true;
+                    return;
+                }
             }
         }
 
@@ -937,6 +982,21 @@ class Constraint : public multi_array::AbstractMultiArrayElement {
     }
 
     /*************************************************************************/
+    inline constexpr bool is_multiple_cover(void) const noexcept {
+        return m_is_multiple_cover;
+    }
+
+    /*************************************************************************/
+    inline constexpr bool is_binary_flow(void) const noexcept {
+        return m_is_binary_flow;
+    }
+
+    /*************************************************************************/
+    inline constexpr bool is_integer_flow(void) const noexcept {
+        return m_is_integer_flow;
+    }
+
+    /*************************************************************************/
     inline constexpr bool is_equation_knapsack(void) const noexcept {
         return m_is_equation_knapsack;
     }
@@ -982,8 +1042,8 @@ class Constraint : public multi_array::AbstractMultiArrayElement {
     }
 
     /*************************************************************************/
-    inline constexpr bool is_binary(void) const noexcept {
-        return m_is_binary;
+    inline constexpr bool has_only_binary_coefficient(void) const noexcept {
+        return m_has_only_binary_coefficient;
     }
 
     /*************************************************************************/

--- a/printemps/model_component/constraint_type_reference.h
+++ b/printemps/model_component/constraint_type_reference.h
@@ -24,6 +24,9 @@ struct ConstraintTypeReference {
     std::vector<Constraint<T_Variable, T_Expression> *> set_covering_ptrs;
     std::vector<Constraint<T_Variable, T_Expression> *> cardinality_ptrs;
     std::vector<Constraint<T_Variable, T_Expression> *> invariant_knapsack_ptrs;
+    std::vector<Constraint<T_Variable, T_Expression> *> multiple_cover_ptrs;
+    std::vector<Constraint<T_Variable, T_Expression> *> binary_flow_ptrs;
+    std::vector<Constraint<T_Variable, T_Expression> *> integer_flow_ptrs;
     std::vector<Constraint<T_Variable, T_Expression> *> equation_knapsack_ptrs;
     std::vector<Constraint<T_Variable, T_Expression> *> bin_packing_ptrs;
     std::vector<Constraint<T_Variable, T_Expression> *> knapsack_ptrs;
@@ -51,6 +54,9 @@ struct ConstraintTypeReference {
         this->set_covering_ptrs.clear();
         this->cardinality_ptrs.clear();
         this->invariant_knapsack_ptrs.clear();
+        this->multiple_cover_ptrs.clear();
+        this->binary_flow_ptrs.clear();
+        this->integer_flow_ptrs.clear();
         this->equation_knapsack_ptrs.clear();
         this->bin_packing_ptrs.clear();
         this->knapsack_ptrs.clear();

--- a/printemps/model_component/variable.h
+++ b/printemps/model_component/variable.h
@@ -46,6 +46,9 @@ class Variable : public multi_array::AbstractMultiArrayElement {
     T_Variable m_lower_bound;
     T_Variable m_upper_bound;
     bool       m_has_bounds;
+
+    double m_lagrangian_coefficient;
+
     bool       m_is_objective_improvable;
     bool       m_is_feasibility_improvable;
     bool       m_has_lower_bound_margin;
@@ -120,6 +123,8 @@ class Variable : public multi_array::AbstractMultiArrayElement {
         m_lower_bound = constant::INT_HALF_MIN;
         m_upper_bound = constant::INT_HALF_MAX;
         m_has_bounds  = false;
+
+        m_lagrangian_coefficient = 0.0;
 
         m_is_objective_improvable   = false;
         m_is_feasibility_improvable = false;
@@ -256,6 +261,17 @@ class Variable : public multi_array::AbstractMultiArrayElement {
     /*************************************************************************/
     inline constexpr bool has_bounds(void) const {
         return m_has_bounds;
+    }
+
+    /*************************************************************************/
+    inline constexpr void set_lagrangian_coefficient(
+        const double a_LAGRANGIAN_COEFFICIENT) {
+        m_lagrangian_coefficient = a_LAGRANGIAN_COEFFICIENT;
+    }
+
+    /*************************************************************************/
+    inline constexpr double lagrangian_coefficient(void) const noexcept {
+        return m_lagrangian_coefficient;
     }
 
     /*************************************************************************/

--- a/printemps/option/option.h
+++ b/printemps/option/option.h
@@ -415,6 +415,11 @@ struct Option {
             utility::to_string(this->tabu_search.frequency_penalty_coefficient,
                                "%f"));
 
+        utility::print(                                           //
+            " -- tabu_search.lagrangian_penalty_coefficient: " +  //
+            utility::to_string(this->tabu_search.lagrangian_penalty_coefficient,
+                               "%f"));
+
         utility::print(                                   //
             " -- tabu_search.pruning_rate_threshold: " +  //
             utility::to_string(this->tabu_search.pruning_rate_threshold, "%f"));

--- a/printemps/option/tabu_search_option.h
+++ b/printemps/option/tabu_search_option.h
@@ -20,6 +20,7 @@ struct TabuSearchOptionConstant {
     static constexpr double DEFAULT_INITIAL_MODIFICATION_RANDOMIZE_RATE = 0.5;
     static constexpr double DEFAULT_MOVE_PRESERVE_RATE                  = 1.0;
     static constexpr double DEFAULT_FREQUENCY_PENALTY_COEFFICIENT       = 1E-5;
+    static constexpr double DEFAULT_LAGRANGIAN_PENALTY_COEFFICIENT      = 1.0;
     static constexpr double DEFAULT_PRUNING_RATE_THRESHOLD              = 1.0;
 
     static constexpr double DEFAULT_IS_ENABLED_SHUFFLE         = true;
@@ -30,8 +31,8 @@ struct TabuSearchOptionConstant {
     static constexpr bool DEFAULT_IS_ENABLED_AUTOMATIC_ITERATION_ADJUSTMENT =
         true;
     static constexpr bool   DEFAULT_IS_ENABLED_INITIAL_MODIFICATION    = true;
-    static constexpr int    DEFAULT_intensity_INCREASE_COUNT_THRESHOLD = 10;
-    static constexpr int    DEFAULT_intensity_DECREASE_COUNT_THRESHOLD = 10;
+    static constexpr int    DEFAULT_INTENSITY_INCREASE_COUNT_THRESHOLD = 10;
+    static constexpr int    DEFAULT_INTENSITY_DECREASE_COUNT_THRESHOLD = 10;
     static constexpr double DEFAULT_ITERATION_INCREASE_RATE            = 1.5;
     static constexpr double DEFAULT_ITERATION_DEREASE_RATE             = 0.9;
     static constexpr double DEFAULT_IGNORE_TABU_IF_GLOBAL_INCUMBENT    = true;
@@ -52,6 +53,7 @@ struct TabuSearchOption {
     tabu_mode::TabuMode tabu_mode;
     double              move_preserve_rate;                           // hidden
     double              frequency_penalty_coefficient;                // hidden
+    double              lagrangian_penalty_coefficient;               // hidden
     double              pruning_rate_threshold;                       // hidden
     bool                is_enabled_shuffle;                           // hidden
     bool                is_enabled_move_curtail;                      // hidden
@@ -91,6 +93,8 @@ struct TabuSearchOption {
             TabuSearchOptionConstant::DEFAULT_MOVE_PRESERVE_RATE;
         this->frequency_penalty_coefficient =
             TabuSearchOptionConstant::DEFAULT_FREQUENCY_PENALTY_COEFFICIENT;
+        this->lagrangian_penalty_coefficient =
+            TabuSearchOptionConstant::DEFAULT_LAGRANGIAN_PENALTY_COEFFICIENT;
         this->pruning_rate_threshold =
             TabuSearchOptionConstant::DEFAULT_PRUNING_RATE_THRESHOLD;
         this->is_enabled_shuffle =
@@ -108,9 +112,9 @@ struct TabuSearchOption {
         this->is_enabled_initial_modification =
             TabuSearchOptionConstant::DEFAULT_IS_ENABLED_INITIAL_MODIFICATION;
         this->intensity_increase_count_threshold = TabuSearchOptionConstant::
-            DEFAULT_intensity_INCREASE_COUNT_THRESHOLD;
+            DEFAULT_INTENSITY_INCREASE_COUNT_THRESHOLD;
         this->intensity_decrease_count_threshold = TabuSearchOptionConstant::
-            DEFAULT_intensity_DECREASE_COUNT_THRESHOLD;
+            DEFAULT_INTENSITY_DECREASE_COUNT_THRESHOLD;
         this->iteration_increase_rate =
             TabuSearchOptionConstant::DEFAULT_ITERATION_INCREASE_RATE;
         this->iteration_decrease_rate =

--- a/printemps/solver/lagrange_dual/lagrange_dual.h
+++ b/printemps/solver/lagrange_dual/lagrange_dual.h
@@ -229,6 +229,8 @@ LagrangeDualResult<T_Variable, T_Expression> solve(
                     sensitivity * model_ptr->sign();
             }
 
+            variable_ptrs[i]->set_lagrangian_coefficient(coefficient);
+
             if (coefficient > 0) {
                 if (model_ptr->is_minimization()) {
                     variable_ptrs[i]->set_value_if_mutable(

--- a/printemps/solver/solver.h
+++ b/printemps/solver/solver.h
@@ -120,7 +120,7 @@ Result<T_Variable, T_Expression> solve(
      * and invariant knapsack).
      */
     if (master_option.is_enabled_chain_move &&
-        !model_ptr->has_zero_one_coefficient_constraints()) {
+        !model_ptr->has_chain_move_effective_constraints()) {
         master_option.is_enabled_chain_move = false;
         utility::print_warning(
             "Chain move was disabled because the problem does not include any "

--- a/printemps/solver/tabu_search/tabu_search.h
+++ b/printemps/solver/tabu_search/tabu_search.h
@@ -372,7 +372,8 @@ TabuSearchResult<T_Variable, T_Expression> solve(
 
             total_scores[i] =
                 trial_solution_scores[i].local_augmented_objective +
-                trial_move_scores[i].frequency_penalty;
+                trial_move_scores[i].frequency_penalty +
+                trial_move_scores[i].lagrangian_penalty;
 
             /**
              * If the move is "tabu", it will be set lower priorities in

--- a/test/model/test_model.cpp
+++ b/test/model/test_model.cpp
@@ -1129,6 +1129,15 @@ TEST_F(TestModel, categorize_constraints) {
     auto& invariant_knapsack = model.create_constraint("invariant_knapsack");
     invariant_knapsack       = z.sum() <= 5;
 
+    auto& multiple_cover = model.create_constraint("multiple_cover");
+    multiple_cover       = z.sum() >= 5;
+
+    auto& binary_flow = model.create_constraint("binary_flow");
+    binary_flow       = z(0) + z(1) + z(2) == z(3) + z(4) + z(5);
+
+    auto& integer_flow = model.create_constraint("integer_flow");
+    integer_flow       = r(0) + r(1) + r(2) == r(3) + r(4) + r(5);
+
     auto& equation_knapsack = model.create_constraint("equation_knapsack");
     equation_knapsack       = z.dot(coefficients) == 30;
 
@@ -1154,7 +1163,7 @@ TEST_F(TestModel, categorize_constraints) {
     intermediate       = 2 * z(0) + 3 * z(1) == x;
 
     auto& general_liner = model.create_constraint("general_liner");
-    general_liner       = x + r.sum() == 50;
+    general_liner       = 2 * x + r.sum() == 50;
 
     auto& nonlinear = model.create_constraint("nonlinear");
     std::function<double(const printemps::neighborhood::Move<int, double>&)> f =
@@ -1172,9 +1181,9 @@ TEST_F(TestModel, categorize_constraints) {
     model.categorize_variables();
     model.categorize_constraints();
 
-    EXPECT_EQ(25, model.number_of_constraints());
+    EXPECT_EQ(28, model.number_of_constraints());
     EXPECT_EQ(1, model.number_of_selection_constraints());
-    EXPECT_EQ(23, model.number_of_enabled_constraints());
+    EXPECT_EQ(26, model.number_of_enabled_constraints());
     EXPECT_EQ(2, model.number_of_disabled_constraints());
 
     auto reference = model.constraint_type_reference();
@@ -1186,6 +1195,9 @@ TEST_F(TestModel, categorize_constraints) {
     EXPECT_EQ(1, static_cast<int>(reference.set_packing_ptrs.size()));
     EXPECT_EQ(1, static_cast<int>(reference.set_covering_ptrs.size()));
     EXPECT_EQ(1, static_cast<int>(reference.invariant_knapsack_ptrs.size()));
+    EXPECT_EQ(1, static_cast<int>(reference.multiple_cover_ptrs.size()));
+    EXPECT_EQ(1, static_cast<int>(reference.binary_flow_ptrs.size()));
+    EXPECT_EQ(1, static_cast<int>(reference.integer_flow_ptrs.size()));
     EXPECT_EQ(1, static_cast<int>(reference.equation_knapsack_ptrs.size()));
     EXPECT_EQ(2, static_cast<int>(reference.bin_packing_ptrs.size()));
     EXPECT_EQ(2, static_cast<int>(reference.knapsack_ptrs.size()));
@@ -2887,6 +2899,104 @@ TEST_F(TestModel, number_of_enabled_constraints) {
 /*****************************************************************************/
 TEST_F(TestModel, number_of_disabled_constraints) {
     /// This method is tested in categorize_constraints().
+}
+
+/*****************************************************************************/
+TEST_F(TestModel, has_chain_move_effective_constraints) {
+    /// None
+    {
+        printemps::model::Model<int, double> model;
+
+        [[maybe_unused]] auto& x = model.create_variables("x", 10, 0, 1);
+        model.categorize_variables();
+        model.categorize_constraints();
+        EXPECT_FALSE(model.has_chain_move_effective_constraints());
+    }
+
+    /// Set Partitioning
+    {
+        printemps::model::Model<int, double> model;
+
+        auto&                  x = model.create_variables("x", 10, 0, 1);
+        [[maybe_unused]] auto& f = model.create_constraint("f", x.sum() == 1);
+
+        model.categorize_variables();
+        model.categorize_constraints();
+        EXPECT_TRUE(model.has_chain_move_effective_constraints());
+    }
+
+    /// Set Packing
+    {
+        printemps::model::Model<int, double> model;
+
+        auto&                  x = model.create_variables("x", 10, 0, 1);
+        [[maybe_unused]] auto& f = model.create_constraint("f", x.sum() <= 1);
+
+        model.categorize_variables();
+        model.categorize_constraints();
+        EXPECT_TRUE(model.has_chain_move_effective_constraints());
+    }
+
+    /// Set Covering
+    {
+        printemps::model::Model<int, double> model;
+
+        auto&                  x = model.create_variables("x", 10, 0, 1);
+        [[maybe_unused]] auto& f = model.create_constraint("f", x.sum() >= 1);
+
+        model.categorize_variables();
+        model.categorize_constraints();
+        EXPECT_TRUE(model.has_chain_move_effective_constraints());
+    }
+
+    /// Cardinality
+    {
+        printemps::model::Model<int, double> model;
+
+        auto&                  x = model.create_variables("x", 10, 0, 1);
+        [[maybe_unused]] auto& f = model.create_constraint("f", x.sum() == 5);
+
+        model.categorize_variables();
+        model.categorize_constraints();
+        EXPECT_TRUE(model.has_chain_move_effective_constraints());
+    }
+
+    /// Invariant Knapsack
+    {
+        printemps::model::Model<int, double> model;
+
+        auto&                  x = model.create_variables("x", 10, 0, 1);
+        [[maybe_unused]] auto& f = model.create_constraint("f", x.sum() <= 5);
+
+        model.categorize_variables();
+        model.categorize_constraints();
+        EXPECT_TRUE(model.has_chain_move_effective_constraints());
+    }
+
+    /// Multiple Cover
+    {
+        printemps::model::Model<int, double> model;
+
+        auto&                  x = model.create_variables("x", 10, 0, 1);
+        [[maybe_unused]] auto& f = model.create_constraint("f", x.sum() >= 5);
+
+        model.categorize_variables();
+        model.categorize_constraints();
+        EXPECT_TRUE(model.has_chain_move_effective_constraints());
+    }
+
+    /// Binary Flow
+    {
+        printemps::model::Model<int, double> model;
+
+        auto&                  x = model.create_variables("x", 10, 0, 1);
+        [[maybe_unused]] auto& f =
+            model.create_constraint("f", x(0) + x(1) == x(2) + x(3));
+
+        model.categorize_variables();
+        model.categorize_constraints();
+        EXPECT_TRUE(model.has_chain_move_effective_constraints());
+    }
 }
 
 /*****************************************************************************/

--- a/test/model_component/test_constraint.cpp
+++ b/test/model_component/test_constraint.cpp
@@ -572,6 +572,42 @@ TEST_F(TestConstraint, setup_constraint_type_invariant_knapsack) {
 }
 
 /*****************************************************************************/
+TEST_F(TestConstraint, setup_constraint_type_multiple_cover) {
+    printemps::model::Model<int, double> model;
+    auto& x = model.create_variables("x", 10, 0, 1);
+    auto  constraint =
+        printemps::model_component::Constraint<int, double>::create_instance();
+    constraint.setup(x.sum() - 5,
+                     printemps::model_component::ConstraintSense::Greater);
+    constraint.setup_constraint_type();
+    EXPECT_TRUE(constraint.is_multiple_cover());
+}
+
+/*****************************************************************************/
+TEST_F(TestConstraint, setup_constraint_type_binary_flow) {
+    printemps::model::Model<int, double> model;
+    auto& x = model.create_variables("x", 10, 0, 1);
+    auto  constraint =
+        printemps::model_component::Constraint<int, double>::create_instance();
+    constraint.setup(x(0) + x(1) + x(2) - x(3) - x(4) - x(5),
+                     printemps::model_component::ConstraintSense::Greater);
+    constraint.setup_constraint_type();
+    EXPECT_TRUE(constraint.is_binary_flow());
+}
+
+/*****************************************************************************/
+TEST_F(TestConstraint, setup_constraint_type_integer_flow) {
+    printemps::model::Model<int, double> model;
+    auto& x = model.create_variables("x", 10, 0, 10);
+    auto  constraint =
+        printemps::model_component::Constraint<int, double>::create_instance();
+    constraint.setup(x(0) + x(1) + x(2) - x(3) - x(4) - x(5),
+                     printemps::model_component::ConstraintSense::Greater);
+    constraint.setup_constraint_type();
+    EXPECT_TRUE(constraint.is_integer_flow());
+}
+
+/*****************************************************************************/
 TEST_F(TestConstraint, setup_constraint_type_equation_knapsack) {
     printemps::model::Model<int, double> model;
     auto coefficients = printemps::utility::sequence(10);
@@ -1138,7 +1174,7 @@ TEST_F(TestConstraint, setup_constraint_type_general_linear) {
 
     auto constraint =
         printemps::model_component::Constraint<int, double>::create_instance();
-    constraint.setup(x + y.sum() - 50,
+    constraint.setup(2 * x + y.sum() - 50,
                      printemps::model_component::ConstraintSense::Equal);
     constraint.setup_constraint_type();
     EXPECT_TRUE(constraint.is_general_linear());
@@ -1893,6 +1929,21 @@ TEST_F(TestConstraint, is_cardinality) {
 /*****************************************************************************/
 TEST_F(TestConstraint, is_invariant_knapsack) {
     /// This method is tested in setup_constraint_type_invariant_knapsack().
+}
+
+/*****************************************************************************/
+TEST_F(TestConstraint, is_multiple_cover) {
+    /// This method is tested in setup_constraint_type_multiple_cover().
+}
+
+/*****************************************************************************/
+TEST_F(TestConstraint, is_binary_flow) {
+    /// This method is tested in setup_constraint_type_binary_flow().
+}
+
+/*****************************************************************************/
+TEST_F(TestConstraint, is_integer_flow) {
+    /// This method is tested in setup_constraint_type_integer_flow().
 }
 
 /*****************************************************************************/

--- a/test/model_component/test_variable.cpp
+++ b/test/model_component/test_variable.cpp
@@ -48,6 +48,7 @@ TEST_F(TestVariable, initialize) {
     EXPECT_EQ(printemps::constant::INT_HALF_MIN, variable.lower_bound());
     EXPECT_EQ(printemps::constant::INT_HALF_MAX, variable.upper_bound());
     EXPECT_FALSE(variable.has_bounds());
+    EXPECT_EQ(0.0, variable.lagrangian_coefficient());
     EXPECT_FALSE(variable.is_objective_improvable());
     EXPECT_FALSE(variable.is_feasibility_improvable());
     EXPECT_TRUE(variable.has_lower_bound_margin());
@@ -254,6 +255,18 @@ TEST_F(TestVariable, upper_bound) {
 /*****************************************************************************/
 TEST_F(TestVariable, has_bounds) {
     /// This method is tested in set_bound().
+}
+
+/*****************************************************************************/
+TEST_F(TestVariable, set_lagrangian_coefficient) {
+    auto variable =
+        printemps::model_component::Variable<int, double>::create_instance();
+    variable.set_lagrangian_coefficient(10.0);
+    EXPECT_FALSE(variable.has_bounds());
+}
+/*****************************************************************************/
+TEST_F(TestVariable, lagrangian_coefficient) {
+    /// This method is tested in lagrangian_coefficient().
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
This PR implements extra penalty for evaluating move scores based on Lagrange dual, and adds New constraint type `Multiple Cover`, `Binary Flow`, and `Integer Flow`.
This PR includes the following commits: