### PR TITLE
Remove .exe suffix from executable names in CMakeLists.txt

### DIFF
--- a/cmake/application/CMakeLists.txt
+++ b/cmake/application/CMakeLists.txt
@@ -39,11 +39,11 @@ endif()
 
 # mps_solver
 add_executable(
-    mps_solver.exe ${TOP_DIR}/application/mps_solver/main.cpp
+    mps_solver ${TOP_DIR}/application/mps_solver/main.cpp
 )
 
 target_include_directories(
-    mps_solver.exe
+    mps_solver
     PRIVATE ${TOP_DIR}/printemps/
     PRIVATE ${TOP_DIR}/external/include/
 )

--- a/cmake/example/CMakeLists.txt
+++ b/cmake/example/CMakeLists.txt
@@ -39,51 +39,51 @@ endif()
 
 # simple_1
 add_executable(
-    simple_1.exe ${TOP_DIR}/example/simple_1.cpp
+    simple_1 ${TOP_DIR}/example/simple_1.cpp
 )
 
 target_include_directories(
-    simple_1.exe
+    simple_1
     PRIVATE ${TOP_DIR}/printemps/
 )
 
 # simple_2
 add_executable(
-    simple_2.exe ${TOP_DIR}/example/simple_2.cpp
+    simple_2 ${TOP_DIR}/example/simple_2.cpp
 )
 
 target_include_directories(
-    simple_2.exe
+    simple_2
     PRIVATE ${TOP_DIR}/printemps/
 )
 
 # knapsack
 add_executable(
-    knapsack.exe ${TOP_DIR}/example/knapsack.cpp
+    knapsack ${TOP_DIR}/example/knapsack.cpp
 )
 
 target_include_directories(
-    knapsack.exe
+    knapsack
     PRIVATE ${TOP_DIR}/printemps/
 )
 
 # bin_packing
 add_executable(
-    bin_packing.exe ${TOP_DIR}/example/bin_packing.cpp
+    bin_packing ${TOP_DIR}/example/bin_packing.cpp
 )
 
 target_include_directories(
-    bin_packing.exe
+    bin_packing
     PRIVATE ${TOP_DIR}/printemps/
 )
 
 # sudoku
 add_executable(
-    sudoku.exe ${TOP_DIR}/example/sudoku.cpp
+    sudoku ${TOP_DIR}/example/sudoku.cpp
 )
 
 target_include_directories(
-    sudoku.exe
+    sudoku
     PRIVATE ${TOP_DIR}/printemps/
 )
 

--- a/printemps/standalone/mps_solver.h
+++ b/printemps/standalone/mps_solver.h
@@ -45,7 +45,7 @@ class MPSSolver {
                   << std::endl;
         std::cout << std::endl;
 
-        std::cout << "Usage: ./mps_solver.exe "
+        std::cout << "Usage: ./mps_solver "
                   << "[-p OPTION_FILE_NAME] "
                   << "[-i INITIAL_SOLUTION_FILE_NAME] "
                   << "[-m MUTABLE_VARIABLE_FILE_NAME] "


### PR DESCRIPTION
It is not common to append `.exe` suffix to executables in non-Windows environments.

I assume this is for the Windows environment, but on Windows, CMake automatically adds the `.exe` suffix.