### PR TITLE
Fix bugs in interpreting RANGES section of MPS files

### DIFF
--- a/printemps/mps/mps.h
+++ b/printemps/mps/mps.h
@@ -307,26 +307,32 @@ struct MPS {
                                 this->constraints[name_new].sense =
                                     MPSConstraintSense::Greater;
                                 this->constraints[name_new].rhs =
-                                    this->constraints[name].rhs + fabs(range);
+                                    this->constraints[name].rhs - fabs(range);
                                 break;
                             }
                             case MPSConstraintSense::Greater: {
                                 this->constraints[name_new].sense =
                                     MPSConstraintSense::Less;
                                 this->constraints[name_new].rhs =
-                                    this->constraints[name].rhs - fabs(range);
+                                    this->constraints[name].rhs + fabs(range);
                                 break;
                             }
                             case MPSConstraintSense::Equal: {
                                 if (range > 0) {
-                                    this->constraints[name_new].sense =
+                                    this->constraints[name].sense =
                                         MPSConstraintSense::Greater;
+
+                                    this->constraints[name_new].sense =
+                                        MPSConstraintSense::Less;
                                     this->constraints[name_new].rhs =
                                         this->constraints[name].rhs +
                                         fabs(range);
                                 } else {
-                                    this->constraints[name_new].sense =
+                                    this->constraints[name].sense =
                                         MPSConstraintSense::Less;
+
+                                    this->constraints[name_new].sense =
+                                        MPSConstraintSense::Greater;
                                     this->constraints[name_new].rhs =
                                         this->constraints[name].rhs -
                                         fabs(range);


### PR DESCRIPTION
fix #219

This PR fixes the interpretation of the RANGES section to conform to https://www.ibm.com/docs/vi/icos/20.1.0?topic=standard-records-in-mps-format .

BTW:

I also have implemented this specification in the past.
https://github.com/msakai/haskell-MIP/blob/bc9dc5318d198f01c8f08595b2bab6af8ba7164d/MIP/src/Numeric/Optimization/MIP/MPSFile.hs#L296-L303

This specification is unnecessarily complex and I believe that we should 撲滅 MPS files ;-)