### PR TITLE
Fix wrong section name in error message in mps.h

### DIFF
--- a/printemps/mps/mps.h
+++ b/printemps/mps/mps.h
@@ -252,7 +252,7 @@ struct MPS {
                                         __FILE__, __LINE__, __func__,
                                         "An undefined constraint or objective "
                                         "function "
-                                        "name is specified in RHS section."));
+                                        "name is specified in COLUMNS section."));
                             }
                         }
                     }


### PR DESCRIPTION
The message refers to the RHS section, even though this error is in the COLUMNS section.