### PR TITLE
Remove unnecessary close() invocation in Python scripts

### DIFF
--- a/script/batch.py
+++ b/script/batch.py
@@ -28,11 +28,9 @@ def run_batch(executable: str, mps_list: list, option_file_name: str) -> list:
 
         with open("status.json", "r") as f:
             status = json.load(f)
-            f.close()
 
         with open("incumbent.json", "r") as f:
             incumbent = json.load(f)
-            f.close()
 
         result = {
             "instance": {

--- a/script/visualize_solutions.py
+++ b/script/visualize_solutions.py
@@ -340,7 +340,6 @@ def main() -> None:
     solution_file_name = args.input_file_name
     with open(solution_file_name, "r") as f:
         solution_object = json.load(f)
-        f.close()
 
     visualizer = Visualizer(
         solution_object,

--- a/script/visualize_trend.py
+++ b/script/visualize_trend.py
@@ -639,7 +639,6 @@ def main() -> None:
 
     with open(trend_file_name, "r") as f:
         instance_name = f.readline().split()[-1]
-        f.close()
 
     visualize_trend(trend_data, instance_name, output_file_name=args.output)
 


### PR DESCRIPTION
They are closed when exiting from `with open(...) as f` blocks