### PR TITLE
allow a variable not appear in COLUMNS section but in the BOUNDS section

### DIFF
--- a/printemps/mps/mps.h
+++ b/printemps/mps/mps.h
@@ -364,10 +364,10 @@ struct MPS {
                     category = items.front();
                     name     = items[2];
                     if (this->variables.find(name) == this->variables.end()) {
-                        throw std::runtime_error(utility::format_error_location(
-                            __FILE__, __LINE__, __func__,
-                            "An undefined variable name is specified in RHS "
-                            "section."));
+                        this->variables[name].sense = MPSVariableSense::Continuous;
+                        this->variables[name].name  = name;
+                        this->variable_names.push_back(name);
+                        this->number_of_variables++;
                     }
                     if (ITEMS_SIZE == 3) {
                         if (category == "FR") {


### PR DESCRIPTION
If a problem is mechanically generated or converted from other formats, there may be variables that do not appear in the `COLUMNS` section but appear for the first time in the `BOUNDS` section.

It would be convenient to be able to process files containing such variables without error.