### PR TITLE
Install signal handlers to shutdown mps_solver gracefully

### DIFF
--- a/printemps/solver/abstract_solver_controller.h
+++ b/printemps/solver/abstract_solver_controller.h
@@ -17,6 +17,7 @@ class AbstractSolverController {
     GlobalState<T_Variable, T_Expression>*             m_global_state_ptr;
     solution::SparseSolution<T_Variable, T_Expression> m_initial_solution;
     utility::TimeKeeper                                m_time_keeper;
+    std::optional<std::function<bool()>>               m_check_interrupt;
     option::Option                                     m_option;
 
     /*************************************************************************/
@@ -77,11 +78,14 @@ class AbstractSolverController {
         const solution::SparseSolution<T_Variable, T_Expression>&
                                    a_INITIAL_SOLUTION,  //
         const utility::TimeKeeper& a_TIME_KEEPER,       //
+        const std::optional<std::function<bool()>>&
+                                   a_CHECK_INTERRUPT,   //
         const option::Option&      a_OPTION) {
         this->setup(a_model_ptr,         //
                     a_global_state_ptr,  //
                     a_INITIAL_SOLUTION,  //
                     a_TIME_KEEPER,       //
+                    a_CHECK_INTERRUPT,   //
                     a_OPTION);
     }
 
@@ -101,11 +105,14 @@ class AbstractSolverController {
         const solution::SparseSolution<T_Variable, T_Expression>&
                                    a_INITIAL_SOLUTION,  //
         const utility::TimeKeeper& a_TIME_KEEPER,       //
+        const std::optional<std::function<bool()>>&
+                                   a_CHECK_INTERRUPT,   //
         const option::Option&      a_OPTION) {
         m_model_ptr        = a_model_ptr;
         m_global_state_ptr = a_global_state_ptr;
         m_initial_solution = a_INITIAL_SOLUTION;
         m_time_keeper      = a_TIME_KEEPER;
+        m_check_interrupt  = a_CHECK_INTERRUPT;
         m_option           = a_OPTION;
     }
 
@@ -144,6 +151,11 @@ class AbstractSolverController {
         search_tree.update(
             incumbent_solution_archive,
             incumbent_holder.global_augmented_incumbent_solution().to_sparse());
+    }
+
+    /*************************************************************************/
+    inline bool check_interrupt(void) {
+        return m_check_interrupt.has_value() && m_check_interrupt.value()();
     }
 
     /*************************************************************************/

--- a/printemps/solver/local_search/controller/local_search_controller.h
+++ b/printemps/solver/local_search/controller/local_search_controller.h
@@ -31,12 +31,15 @@ class LocalSearchController
         const solution::SparseSolution<T_Variable, T_Expression>&
                                    a_INITIAL_SOLUTION,  //
         const utility::TimeKeeper& a_TIME_KEEPER,       //
+        const std::optional<std::function<bool()>>&
+                                   a_CHECK_INTERRUPT,   //
         const option::Option&      a_OPTION) {
         this->initialize();
         this->setup(a_model_ptr,         //
                     a_global_state_ptr,  //
                     a_INITIAL_SOLUTION,  //
                     a_TIME_KEEPER,       //
+                    a_CHECK_INTERRUPT,   //
                     a_OPTION);
     }
 
@@ -44,6 +47,18 @@ class LocalSearchController
     inline void initialize(void) {
         AbstractSolverController<T_Variable, T_Expression>::initialize();
         m_result.initialize();
+    }
+
+    /*************************************************************************/
+    inline bool satisfy_interrupted_skip_condition(
+        const bool a_IS_ENABLED_PRINT) {
+        if (this->check_interrupt()) {
+            utility::print_message(  //
+                "Local search was skipped because of interruption.",
+                a_IS_ENABLED_PRINT);
+            return true;
+        }
+        return false;
     }
 
     /*************************************************************************/
@@ -76,6 +91,16 @@ class LocalSearchController
     /*************************************************************************/
     inline void run(void) {
         const double TOTAL_ELAPSED_TIME = this->m_time_keeper.clock();
+
+        /**
+         * Skip local search if interrupted.
+         */
+        if (this->satisfy_interrupted_skip_condition(
+                this->m_option.output.verbose >= option::verbose::Outer)) {
+            m_result.initialize();
+            return;
+        }
+
         /**
          * Skip local search if the time is over.
          */

--- a/printemps/solver/solver.h
+++ b/printemps/solver/solver.h
@@ -24,6 +24,7 @@ class Solver {
     GlobalState<T_Variable, T_Expression>              m_global_state;
     solution::SparseSolution<T_Variable, T_Expression> m_current_solution;
     utility::TimeKeeper                                m_time_keeper;
+    std::optional<std::function<bool()>>               m_check_interrupt;
 
     option::Option m_option_original;
     option::Option m_option;
@@ -148,6 +149,7 @@ class Solver {
                                 &m_global_state,     //
                                 m_current_solution,  //
                                 m_time_keeper,       //
+                                m_check_interrupt,   //
                                 m_option);
         m_pdlp_controller.run();
     }
@@ -158,6 +160,7 @@ class Solver {
                                          &m_global_state,     //
                                          m_current_solution,  //
                                          m_time_keeper,       //
+                                         m_check_interrupt,   //
                                          m_option);
         m_lagrange_dual_controller.run();
         m_current_solution = m_global_state.incumbent_holder
@@ -171,6 +174,7 @@ class Solver {
                                         &m_global_state,     //
                                         m_current_solution,  //
                                         m_time_keeper,       //
+                                        m_check_interrupt,   //
                                         m_option);
         m_local_search_controller.run();
         m_current_solution = m_global_state.incumbent_holder
@@ -184,6 +188,7 @@ class Solver {
                                        &m_global_state,     //
                                        m_current_solution,  //
                                        m_time_keeper,       //
+                                       m_check_interrupt,   //
                                        m_option);
         m_tabu_search_controller.run();
         m_current_solution = m_global_state.incumbent_holder
@@ -213,6 +218,7 @@ class Solver {
     /*************************************************************************/
     inline void initialize(void) {
         m_model_ptr = nullptr;
+        m_check_interrupt = std::nullopt;
         m_global_state.initialize();
 
         m_current_solution.initialize();
@@ -248,6 +254,16 @@ class Solver {
         m_model_ptr       = a_model_ptr;
         m_option_original = a_OPTION;
         m_option          = a_OPTION;
+    }
+
+    /*************************************************************************/
+    inline void set_check_interrupt(const std::optional<std::function<bool(void)>>& a_check_interrupt) {
+        m_check_interrupt = a_check_interrupt;
+    }
+
+    /*************************************************************************/
+    inline void clear_check_interrupt(void) {
+        m_check_interrupt.reset();
     }
 
     /*************************************************************************/

--- a/printemps/std.h
+++ b/printemps/std.h
@@ -22,6 +22,7 @@
 #include <limits>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <random>
 #include <regex>
 #include <set>


### PR DESCRIPTION
A user may interrupt the computation by typing Ctrl + C, or in a solver competition environment, the computation is terminated by the system after the specified amount of time has elapsed.

It is desirable to save the incumbent solution even if the execution is interrupted.

This can be done by handling signals and shutting down the algorithm gracefully.

In this PR, I choose to install signal handlers in `mps_solver.h`, but one might want to install signal handlers in `main.cpp` instead.