### PR TITLE
Stop using scientific notation in o-line and flush standard output after o-line output

### DIFF
--- a/extra/pb_competition_2025/pb_competition_2025_solver.h
+++ b/extra/pb_competition_2025/pb_competition_2025_solver.h
@@ -186,7 +186,8 @@ class PBCompetition2025Solver {
                         current_feasible_incumbent_objective;
                     std::cout << "o " << std::fixed << std::setprecision(0)
                               << current_feasible_incumbent_objective
-                              << std::endl;
+                              << std::endl
+                              << std::flush;
                 }
             };
 

--- a/extra/pb_competition_2025/pb_competition_2025_solver.h
+++ b/extra/pb_competition_2025/pb_competition_2025_solver.h
@@ -184,7 +184,8 @@ class PBCompetition2025Solver {
                     feasible_incumbent_objective) {
                     feasible_incumbent_objective =
                         current_feasible_incumbent_objective;
-                    std::cout << "o " << current_feasible_incumbent_objective
+                    std::cout << "o " << std::fixed << std::setprecision(0)
+                              << current_feasible_incumbent_objective
                               << std::endl;
                 }
             };


### PR DESCRIPTION
According to the [Solver Requirements](https://www.cril.univ-artois.fr/PB24/competitionRequirements.pdf):

> Whenever the solver finds a solution with a better value of the objective function (PBO) or of the current cost (WBO), it is asked to print an ”o ” line with the current value of the objective function/cost. Therefore, an ”o ” line must contain the lower case o followed by a space and then by an integer which represents the better value of the objective function/cost.

I guess it is better to use  the standard notation of integers (e.g. 10081600) and to avoid using scientific notation (e.g. 1.00816e+07).

Also it is advised to flush immediately the output stream after o-line output.

> Programmers are advised to flush immediately the output stream.