### PR TITLE
Fix a bug when importing soft >=-constraints where all coefficients are negative

### DIFF
--- a/printemps/model/model.h
+++ b/printemps/model/model.h
@@ -3788,7 +3788,7 @@ class Model {
                     const auto INDEX = soft_constraint_indices_greater[i];
                     if (SOFT_CONSTRAINT.is_all_coefficient_negative()) {
                         soft_constraint_proxy_greater_minus(INDEX) =
-                            (-expression >=
+                            (-expression <=
                              -LOWER_BOUND *
                                  soft_constraint_slack_proxy_greater_minus(
                                      INDEX));


### PR DESCRIPTION
If the sign is reversed, the direction of the inequality sign must also be reversed, as done in the case of `opb::OPBConstraintSense::Less`.