### PR TITLE
Change Variable::set_bound to throw a specialized exception for contradicting bounds

### DIFF
--- a/extra/pb_competition_2025/main.cpp
+++ b/extra/pb_competition_2025/main.cpp
@@ -19,6 +19,9 @@ int main(const int argc, const char *argv[]) {
         printemps::extra::pb_competition_2025::PBCompetition2025Solver(argc,
                                                                        argv)
             .run();
+    } catch (const printemps::model::InfeasibleError &e) {
+        print_comment_lines(e.what());
+        std::cout << "s UNSATISFIABLE" << std::endl;
     } catch (const std::exception &e) {
         print_comment_lines(e.what());
         std::cout << "s UNSUPPORTED" << std::endl;

--- a/printemps/model/model.h
+++ b/printemps/model/model.h
@@ -4719,6 +4719,7 @@ class Model {
     }
 };
 using IPModel = Model<int, double>;
+using InfeasibleError = printemps::model_component::InfeasibleError;
 }  // namespace printemps::model
 #endif
 /*****************************************************************************/

--- a/printemps/model_component/variable.h
+++ b/printemps/model_component/variable.h
@@ -52,6 +52,14 @@ struct VariableExtension {
 };
 
 /*****************************************************************************/
+
+class InfeasibleError : public std::runtime_error {
+public:
+    explicit InfeasibleError(const std::string& msg)
+        : std::runtime_error(msg) {}
+};
+
+/*****************************************************************************/
 template <class T_Variable, class T_Expression>
 class Variable : public multi_array::AbstractMultiArrayElement {
     /**
@@ -211,7 +219,7 @@ class Variable : public multi_array::AbstractMultiArrayElement {
     inline void set_bound(const T_Variable a_LOWER_BOUND,
                           const T_Variable a_UPPER_BOUND) {
         if (a_LOWER_BOUND > a_UPPER_BOUND) {
-            throw std::runtime_error(utility::format_error_location(
+            throw InfeasibleError(utility::format_error_location(
                 __FILE__, __LINE__, __func__,
                 "The specified lower bound is bigger than the specified upper "
                 "bound. lower bound: " +


### PR DESCRIPTION
So that `extra/pb_competition_2025/main.cpp` can report unsatisfiability.

The behavior can be tested using `normalized-rand5c0b12.cudf.paranoid.opb` from [normalized-PB10.tar](https://www.cril.univ-artois.fr/PB24/benchs/normalized-PB10.tar).