### PR TITLE
Remove macos + gcc-12 from build matrix of GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,13 +25,11 @@ jobs:
       - { os: ubuntu-24.04, cc: clang-18, cxx: clang++-18 } # 18.1.3
       # For macOS 14, the available compilers are specified according to
       # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
-      - { os: macos-14, cc: gcc-12, cxx: g++-12 } # 12.4.0 
       - { os: macos-14, cc: gcc-13, cxx: g++-13 } # 13.4.0 
       - { os: macos-14, cc: gcc-14, cxx: g++-14 } # 14.3.0
       - { os: macos-14, cc: gcc-15, cxx: g++-15 } # 15.1.0 
       # For macOS 15, the available compilers are specified according to
       # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
-      - { os: macos-15, cc: gcc-12, cxx: g++-12 } # 12.4.0 
       - { os: macos-15, cc: gcc-13, cxx: g++-13 } # 13.4.0 
       - { os: macos-15, cc: gcc-14, cxx: g++-14 } # 14.3.0 
       - { os: macos-15, cc: gcc-15, cxx: g++-15 } # 15.1.0 


### PR DESCRIPTION
GCC 12 was removed from macOS runner images.

- https://github.com/actions/runner-images/pull/13253
- https://github.com/actions/runner-images/pull/13256