### PR TITLE
Augment initial solution with values for negated variables and product variables

### DIFF
--- a/printemps/opb/opb.h
+++ b/printemps/opb/opb.h
@@ -618,6 +618,42 @@ struct OPB {
 
         this->setup_variable_information();
     }
+
+    inline void augment_solution(
+        std::unordered_map<std::string, int> &a_VARIABLES) {
+        // augment negated variables
+        for (const auto &variable_name : negated_variable_names) {
+            const auto &negated_variable_name = "~" + variable_name;
+            if (a_VARIABLES.find(negated_variable_name) == a_VARIABLES.end() &&
+                a_VARIABLES.find(variable_name) != a_VARIABLES.end()) {
+                a_VARIABLES[negated_variable_name] =
+                    1 - a_VARIABLES[variable_name];
+            }
+        }
+
+        // augment product variables
+        for (const auto &product_variable_name : product_variable_names) {
+            if (a_VARIABLES.find(product_variable_name.first) !=
+                a_VARIABLES.end()) {
+                continue;
+            }
+
+            int  value     = 1;
+            bool not_found = false;
+            for (const auto &variable_name : product_variable_name.second) {
+                if (a_VARIABLES.find(variable_name) == a_VARIABLES.end()) {
+                    not_found = true;
+                    break;
+                } else {
+                    value *= a_VARIABLES[variable_name];
+                }
+            }
+
+            if (!not_found) {
+                a_VARIABLES[product_variable_name.first] = value;
+            }
+        }
+    }
 };
 }  // namespace printemps::opb
 #endif

--- a/printemps/standalone/standalone.h
+++ b/printemps/standalone/standalone.h
@@ -199,9 +199,11 @@ class Standalone {
          * values will be used.
          */
         if (!m_argparser.initial_solution_file_name.empty()) {
-            const auto INITIAL_SOLUTION =
-                printemps::helper::read_names_and_values(
-                    m_argparser.initial_solution_file_name);
+            auto INITIAL_SOLUTION = printemps::helper::read_names_and_values(
+                m_argparser.initial_solution_file_name);
+            if (EXTENSION == "opb" || EXTENSION == "wbo") {
+                m_opb.augment_solution(INITIAL_SOLUTION);
+            }
             m_model.import_solution(INITIAL_SOLUTION);
         }
 


### PR DESCRIPTION
Since the fact that negative literals are represented by separate variables and the naming convention for product variables is part of PRINTEMPS's internal design, users should not be required to have that knowledge when providing initial solutions from outside the program.

Therefore, this PR makes PRINTEMPS calculate values for those variables automatically when values for those variables are not specified in the initial solution.