### PR TITLE
Fix SEGV when importing OPB with negated variables

### DIFF
--- a/printemps/model/model.h
+++ b/printemps/model/model.h
@@ -4000,7 +4000,7 @@ class Model {
                     *variable_ptrs[NEGATED_VARIABLE_NAME] +
                         *variable_ptrs["~" + NEGATED_VARIABLE_NAME] ==
                     1;
-                hard_constraint_proxy(i).set_name(
+                negated_variable_constraint_proxy(i).set_name(
                     "negated_variable_constraints_" + NEGATED_VARIABLE_NAME);
             }
         }


### PR DESCRIPTION
## Summary
Fixed a bug where the wrong variable reference was being used when setting the name of negated variable constraints.

## Key Changes
- Changed `hard_constraint_proxy(i)` to `negated_variable_constraint_proxy(i)` when setting the constraint name for negated variables
- This ensures the constraint name is set on the correct constraint object rather than a generic hard constraint proxy

## Details
The code was incorrectly using `hard_constraint_proxy(i)` to set the name of negated variable constraints.

I noticed the issue with the folllowing input file:

```
* #variable= 5 #constraint= 3 #equal= 1 intsize= 4 #product= 5 sizeproduct= 13
min: +1 x2 x3 -1 x3 ;
+1 x1 +4 x1 ~x2 -2 x5 >= 2;
+1 x4 +4 x3 >= 10;
+2 x2 x3 +3 x4 ~x5 +2 ~x1 x2 +3 ~x1 x2 x3 ~x4 ~x5 = 5;
```

The fix uses the more specific `negated_variable_constraint_proxy(i)` reference, which properly targets the negated variable constraint being configured. 