### PR TITLE
Upgrade integer types from int to int64_t for OPB parsing

### DIFF
--- a/extra/pb_competition_2025/pb_competition_2025_solver.h
+++ b/extra/pb_competition_2025/pb_competition_2025_solver.h
@@ -134,7 +134,7 @@ class PBCompetition2025Solver {
          * Check the metadata of the specified OPB file.
          */
         auto metadata = opb::OPB::check_metadata(m_argparser.pb_file_name);
-        if (metadata.intsize >= 32) {
+        if (metadata.intsize > 53) {
             std::cout << "s UNSUPPORTED" << std::endl;
             exit(0);
         }

--- a/printemps/opb/opb.h
+++ b/printemps/opb/opb.h
@@ -208,13 +208,13 @@ struct OPB {
                 }
             } else if (token == "mincost=") {
                 if (stream >> token) {
-                    metadata.mincost = std::stoi(token);
+                    metadata.mincost = std::stoll(token);
                 } else {
                     is_valid = false;
                 }
             } else if (token == "maxcost=") {
                 if (stream >> token) {
-                    metadata.maxcost = std::stoi(token);
+                    metadata.maxcost = std::stoll(token);
                 } else {
                     is_valid = false;
                 }
@@ -256,10 +256,10 @@ struct OPB {
         }
         if (tokens.size() == 0) {
             top_cost.is_defined = false;
-            top_cost.value      = std::numeric_limits<int>::max();
+            top_cost.value      = std::numeric_limits<int64_t>::max();
         } else if (tokens.size() == 1) {
             top_cost.is_defined = true;
-            top_cost.value      = std::stoi(tokens[0]);
+            top_cost.value      = std::stoll(tokens[0]);
         } else {
             throw std::runtime_error(utility::format_error_location(
                 __FILE__, __LINE__, __func__,
@@ -302,12 +302,12 @@ struct OPB {
         const size_t SQUARE_BRACKET_START = a_LINE.find('[');
         const size_t SQUARE_BRACKET_END   = a_LINE.find(']');
 
-        double weight = 0.0;
+        int64_t weight = 0;
 
         if (SQUARE_BRACKET_START != std::string::npos &&
             SQUARE_BRACKET_END != std::string::npos &&
             SQUARE_BRACKET_START < SQUARE_BRACKET_END) {
-            weight = std::stoi(
+            weight = std::stoll(
                 a_LINE.substr(SQUARE_BRACKET_START + 1,
                               SQUARE_BRACKET_END - SQUARE_BRACKET_START - 1));
         } else {
@@ -330,7 +330,7 @@ struct OPB {
     inline static OPBConstraint parse_hard_constraint(const std::string &a_LINE,
                                                       const int a_INDEX) {
         OPBConstraint hard_constraint = OPB::parse_constraint(a_LINE);
-        hard_constraint.weight        = std::numeric_limits<int>::max();
+        hard_constraint.weight        = std::numeric_limits<int64_t>::max();
         hard_constraint.name = "hard_constraint_" + std::to_string(a_INDEX);
         return hard_constraint;
     }
@@ -362,11 +362,11 @@ struct OPB {
         const std::string RHS_STRING =
             a_CONSTRAINT_STRING.substr(pos + op.size());
         OPBConstraint constraint;
-        constraint.weight = std::numeric_limits<int>::max();
+        constraint.weight = std::numeric_limits<int64_t>::max();
         constraint.sense  = sense;
         constraint.name   = "";
         constraint.terms  = OPB::parse_terms(LHS_STRING);
-        constraint.rhs    = std::stoi(RHS_STRING);
+        constraint.rhs    = std::stoll(RHS_STRING);
         return constraint;
     }
 
@@ -384,9 +384,9 @@ struct OPB {
         OPBTerm              term;
         std::vector<OPBTerm> terms;
 
-        bool   is_number_last_read  = false;
-        double previous_coefficient = 0.0;
-        double current_coefficient  = 0.0;
+        bool    is_number_last_read  = false;
+        int64_t previous_coefficient = 0;
+        int64_t current_coefficient  = 0;
 
         std::unordered_set<std::string> variable_names_set;
 
@@ -408,7 +408,7 @@ struct OPB {
                         "coefficients."));
                 }
                 previous_coefficient = current_coefficient;
-                current_coefficient  = std::stoi(tokens[i]);
+                current_coefficient  = std::stoll(tokens[i]);
                 is_number_last_read  = true;
             }
 

--- a/printemps/opb/opb_constraint.h
+++ b/printemps/opb/opb_constraint.h
@@ -12,11 +12,11 @@
 namespace printemps::opb {
 /*****************************************************************************/
 struct OPBConstraint {
-    int                  weight;
+    int64_t              weight;
     OPBConstraintSense   sense;
     std::string          name;
     std::vector<OPBTerm> terms;
-    int                  rhs;
+    int64_t              rhs;
 
     /*************************************************************************/
     OPBConstraint(void) {
@@ -25,11 +25,11 @@ struct OPBConstraint {
 
     /*************************************************************************/
     inline void initialize(void) {
-        this->weight = std::numeric_limits<int>::max();
+        this->weight = std::numeric_limits<int64_t>::max();
         this->sense  = OPBConstraintSense::Less;
         this->name   = "";
         this->terms.clear();
-        this->rhs = 0.0;
+        this->rhs = 0;
     }
 
     /*************************************************************************/

--- a/printemps/opb/opb_metadata.h
+++ b/printemps/opb/opb_metadata.h
@@ -19,10 +19,10 @@ struct OPBMetadata {
     /**
      * The following members are for WBO.
      */
-    int       number_of_soft_constraints;
-    int       mincost;
-    int       maxcost;
-    long long sumcost;
+    int     number_of_soft_constraints;
+    int64_t mincost;
+    int64_t maxcost;
+    int64_t sumcost;
 
     /*************************************************************************/
     OPBMetadata(void) {

--- a/printemps/opb/opb_term.h
+++ b/printemps/opb/opb_term.h
@@ -9,7 +9,7 @@
 namespace printemps::opb {
 /*****************************************************************************/
 struct OPBTerm {
-    int                      coefficient;
+    int64_t                  coefficient;
     std::vector<std::string> variable_names;
 
     /*************************************************************************/

--- a/printemps/opb/opb_top_cost.h
+++ b/printemps/opb/opb_top_cost.h
@@ -9,8 +9,8 @@
 namespace printemps::opb {
 /*****************************************************************************/
 struct OPBTopCost {
-    bool is_defined;
-    int  value;
+    bool    is_defined;
+    int64_t value;
 
     /*************************************************************************/
     OPBTopCost(void) {
@@ -20,7 +20,7 @@ struct OPBTopCost {
     /*************************************************************************/
     inline void initialize(void) {
         this->is_defined = false;
-        this->value      = std::numeric_limits<int>::max();
+        this->value      = std::numeric_limits<int64_t>::max();
     }
 };
 }  // namespace printemps::opb

--- a/printemps/std.h
+++ b/printemps/std.h
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <cmath>
 #include <csignal>
+#include <cstdint>
 #include <cstdlib>
 #include <ctime>
 #include <deque>

--- a/test/opb/test_opb.cpp
+++ b/test/opb/test_opb.cpp
@@ -47,7 +47,7 @@ TEST_F(TestOPB, initialize) {
     EXPECT_EQ(0, pb.metadata.sumcost);
 
     EXPECT_FALSE(pb.top_cost.is_defined);
-    EXPECT_EQ(std::numeric_limits<int>::max(), pb.top_cost.value);
+    EXPECT_EQ(std::numeric_limits<int64_t>::max(), pb.top_cost.value);
 
     EXPECT_TRUE(pb.variable_names.empty());
     EXPECT_TRUE(pb.negated_variable_names.empty());
@@ -108,13 +108,13 @@ TEST_F(TestOPB, parse_top_cost) {
     {
         const auto TOP_COST = opb::OPB::parse_top_cost("soft:");
         EXPECT_FALSE(TOP_COST.is_defined);
-        EXPECT_EQ(std::numeric_limits<int>::max(), TOP_COST.value);
+        EXPECT_EQ(std::numeric_limits<int64_t>::max(), TOP_COST.value);
     }
 
     {
         const auto TOP_COST = opb::OPB::parse_top_cost("Soft:");
         EXPECT_FALSE(TOP_COST.is_defined);
-        EXPECT_EQ(std::numeric_limits<int>::max(), TOP_COST.value);
+        EXPECT_EQ(std::numeric_limits<int64_t>::max(), TOP_COST.value);
     }
 
     {

--- a/test/opb/test_opb_top_cost.cpp
+++ b/test/opb/test_opb_top_cost.cpp
@@ -23,7 +23,7 @@ class TestOPBTopCost : public ::testing::Test {
 TEST_F(TestOPBTopCost, initialize) {
     opb::OPBTopCost top_cost;
     EXPECT_FALSE(top_cost.is_defined);
-    EXPECT_EQ(std::numeric_limits<int>::max(), top_cost.value);
+    EXPECT_EQ(std::numeric_limits<int64_t>::max(), top_cost.value);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
This PR upgrades integer types used in OPB (Pseudo-Boolean) file parsing from `int` to `int64_t` to support larger coefficient and cost values that may exceed 32-bit integer limits.

## Key Changes
- **OPB parsing functions**: Changed `std::stoi()` to `std::stoll()` for parsing coefficients, costs, and RHS values to handle 64-bit integers
- **Data structure fields**: Updated the following types from `int` to `int64_t`:
  - `OPBConstraint`: `weight` and `rhs` fields
  - `OPBMetadata`: `mincost`, `maxcost`, and `sumcost` fields
  - `OPBTopCost`: `value` field
  - `OPBTerm`: `coefficient` field
- **Numeric limits**: Changed `std::numeric_limits<int>::max()` to `std::numeric_limits<int64_t>::max()` throughout the codebase
- **Local variables**: Updated coefficient and weight variables from `double`/`int` to `int64_t` in parsing functions
- **Metadata validation**: Updated intsize check from `>= 32` to `> 53` to properly validate 64-bit integer support (53 bits for safe double precision)
- **Tests**: Updated test assertions to use `int64_t` limits

## Notable Details
- The change maintains backward compatibility while extending support for larger problem instances
- All parsing functions now consistently use 64-bit integer types for coefficients and costs
- The intsize validation threshold change reflects the actual precision limits of 64-bit integers in floating-point representation
