### PR TITLE
Guard bound-tightening cast against double overflow

### DIFF
--- a/printemps/preprocess/problem_size_reducer.h
+++ b/printemps/preprocess/problem_size_reducer.h
@@ -324,11 +324,18 @@ class ProblemSizeReducer {
                  * ax+b<=0 with a>0 (or ax+b>=0 with a<0), the lower bound of
                  * the variable will be tightened by floor(-b/a).
                  */
+                const double bound_floor_d = std::floor(bound_temp);
+                const bool   bound_floor_is_safe =
+                    std::isfinite(bound_floor_d) &&
+                    std::abs(bound_floor_d) <
+                        static_cast<double>(BOUND_LIMIT);
                 auto bound_floor =
-                    static_cast<T_Variable>(std::floor(bound_temp));
+                    bound_floor_is_safe
+                        ? static_cast<T_Variable>(bound_floor_d)
+                        : variable_upper_bound;
 
-                if (bound_floor < variable_upper_bound &&
-                    abs(bound_floor) < BOUND_LIMIT) {
+                if (bound_floor_is_safe &&
+                    bound_floor < variable_upper_bound) {
                     if (a_constraint_ptr->name() == "") {
                         utility::print_message(
                             "The upper bound of the variable " +
@@ -371,11 +378,18 @@ class ProblemSizeReducer {
                  * ax+b>=0 with a>0 (or ax+b<=0 with a<0), the upper bound of
                  * the variable will be tightened by ceil(-b/a).
                  */
+                const double bound_ceil_d = std::ceil(bound_temp);
+                const bool   bound_ceil_is_safe =
+                    std::isfinite(bound_ceil_d) &&
+                    std::abs(bound_ceil_d) <
+                        static_cast<double>(BOUND_LIMIT);
                 auto bound_ceil =
-                    static_cast<T_Variable>(std::ceil(bound_temp));
+                    bound_ceil_is_safe
+                        ? static_cast<T_Variable>(bound_ceil_d)
+                        : variable_lower_bound;
 
-                if (bound_ceil > variable_lower_bound &&
-                    abs(bound_ceil) < BOUND_LIMIT) {
+                if (bound_ceil_is_safe &&
+                    bound_ceil > variable_lower_bound) {
                     if (a_constraint_ptr->name() == "") {
                         utility::print_message(  //
                             "The lower bound of the variable " +
@@ -424,39 +438,47 @@ class ProblemSizeReducer {
             auto variable_upper_bound = variable_ptr->upper_bound();
 
             if (a_constraint_ptr->is_greater_or_equal()) {
-                auto bound_temp = -(constraint_upper_bound -
+                auto         bound_temp    = -(constraint_upper_bound -
                                     coefficient * variable_upper_bound) /
                                   coefficient;
-                auto bound_ceil =
-                    static_cast<T_Variable>(std::ceil(bound_temp));
-                if (bound_ceil > variable_lower_bound &&
-                    abs(bound_ceil) < BOUND_LIMIT) {
-                    utility::print_message(  //
-                        "The lower bound of the variable " +
-                            variable_ptr->name() + " was tightened by " +
-                            std::to_string(bound_ceil) + ".",
-                        a_IS_ENABLED_PRINT);
-                    variable_ptr->set_bound(bound_ceil, variable_upper_bound);
-                    is_variable_bound_updated = true;
-                    (*variable_bound_update_count_ptr)++;
+                const double bound_ceil_d  = std::ceil(bound_temp);
+                if (std::isfinite(bound_ceil_d) &&
+                    std::abs(bound_ceil_d) <
+                        static_cast<double>(BOUND_LIMIT)) {
+                    auto bound_ceil = static_cast<T_Variable>(bound_ceil_d);
+                    if (bound_ceil > variable_lower_bound) {
+                        utility::print_message(  //
+                            "The lower bound of the variable " +
+                                variable_ptr->name() + " was tightened by " +
+                                std::to_string(bound_ceil) + ".",
+                            a_IS_ENABLED_PRINT);
+                        variable_ptr->set_bound(bound_ceil,
+                                                variable_upper_bound);
+                        is_variable_bound_updated = true;
+                        (*variable_bound_update_count_ptr)++;
+                    }
                 }
             }
             if (a_constraint_ptr->is_less_or_equal()) {
-                auto bound_temp = -(constraint_lower_bound -
+                auto         bound_temp    = -(constraint_lower_bound -
                                     coefficient * variable_lower_bound) /
                                   coefficient;
-                auto bound_floor =
-                    static_cast<T_Variable>(std::floor(bound_temp));
-                if (bound_floor < variable_upper_bound &&
-                    abs(bound_floor) < BOUND_LIMIT) {
-                    utility::print_message(  //
-                        "The upper bound of the variable " +
-                            variable_ptr->name() + " was tightened by " +
-                            std::to_string(bound_floor) + ".",
-                        a_IS_ENABLED_PRINT);
-                    variable_ptr->set_bound(variable_lower_bound, bound_floor);
-                    is_variable_bound_updated = true;
-                    (*variable_bound_update_count_ptr)++;
+                const double bound_floor_d = std::floor(bound_temp);
+                if (std::isfinite(bound_floor_d) &&
+                    std::abs(bound_floor_d) <
+                        static_cast<double>(BOUND_LIMIT)) {
+                    auto bound_floor = static_cast<T_Variable>(bound_floor_d);
+                    if (bound_floor < variable_upper_bound) {
+                        utility::print_message(  //
+                            "The upper bound of the variable " +
+                                variable_ptr->name() + " was tightened by " +
+                                std::to_string(bound_floor) + ".",
+                            a_IS_ENABLED_PRINT);
+                        variable_ptr->set_bound(variable_lower_bound,
+                                                bound_floor);
+                        is_variable_bound_updated = true;
+                        (*variable_bound_update_count_ptr)++;
+                    }
                 }
             }
         }
@@ -470,39 +492,47 @@ class ProblemSizeReducer {
             auto variable_upper_bound = variable_ptr->upper_bound();
 
             if (a_constraint_ptr->is_greater_or_equal()) {
-                auto bound_temp = -(constraint_upper_bound -
+                auto         bound_temp    = -(constraint_upper_bound -
                                     coefficient * variable_lower_bound) /
                                   coefficient;
-                auto bound_floor =
-                    static_cast<T_Variable>(std::floor(bound_temp));
-                if (bound_floor < variable_upper_bound &&
-                    abs(bound_floor) < BOUND_LIMIT) {
-                    utility::print_message(  //
-                        "The upper bound of the variable " +
-                            variable_ptr->name() + " was tightened by " +
-                            std::to_string(bound_floor) + ".",
-                        a_IS_ENABLED_PRINT);
-                    variable_ptr->set_bound(variable_lower_bound, bound_floor);
-                    is_variable_bound_updated = true;
-                    (*variable_bound_update_count_ptr)++;
+                const double bound_floor_d = std::floor(bound_temp);
+                if (std::isfinite(bound_floor_d) &&
+                    std::abs(bound_floor_d) <
+                        static_cast<double>(BOUND_LIMIT)) {
+                    auto bound_floor = static_cast<T_Variable>(bound_floor_d);
+                    if (bound_floor < variable_upper_bound) {
+                        utility::print_message(  //
+                            "The upper bound of the variable " +
+                                variable_ptr->name() + " was tightened by " +
+                                std::to_string(bound_floor) + ".",
+                            a_IS_ENABLED_PRINT);
+                        variable_ptr->set_bound(variable_lower_bound,
+                                                bound_floor);
+                        is_variable_bound_updated = true;
+                        (*variable_bound_update_count_ptr)++;
+                    }
                 }
             }
             if (a_constraint_ptr->is_less_or_equal()) {
-                auto bound_temp = -(constraint_lower_bound -
+                auto         bound_temp   = -(constraint_lower_bound -
                                     coefficient * variable_upper_bound) /
                                   coefficient;
-                auto bound_ceil =
-                    static_cast<T_Variable>(std::ceil(bound_temp));
-                if (bound_ceil > variable_lower_bound &&
-                    abs(bound_ceil) < BOUND_LIMIT) {
-                    utility::print_message(  //
-                        "The lower bound of the variable " +
-                            variable_ptr->name() + " was tightened by " +
-                            std::to_string(bound_ceil) + ".",
-                        a_IS_ENABLED_PRINT);
-                    variable_ptr->set_bound(bound_ceil, variable_upper_bound);
-                    is_variable_bound_updated = true;
-                    (*variable_bound_update_count_ptr)++;
+                const double bound_ceil_d = std::ceil(bound_temp);
+                if (std::isfinite(bound_ceil_d) &&
+                    std::abs(bound_ceil_d) <
+                        static_cast<double>(BOUND_LIMIT)) {
+                    auto bound_ceil = static_cast<T_Variable>(bound_ceil_d);
+                    if (bound_ceil > variable_lower_bound) {
+                        utility::print_message(  //
+                            "The lower bound of the variable " +
+                                variable_ptr->name() + " was tightened by " +
+                                std::to_string(bound_ceil) + ".",
+                            a_IS_ENABLED_PRINT);
+                        variable_ptr->set_bound(bound_ceil,
+                                                variable_upper_bound);
+                        is_variable_bound_updated = true;
+                        (*variable_bound_update_count_ptr)++;
+                    }
                 }
             }
         }


### PR DESCRIPTION
I cherry-picked this change from #241, since it is not a Python-binding-specific problem.

When a propagated bound is computed in double precision, the value could exceed the int range. Casting such a value with `static_cast<int>` is undefined behavior; on MSVC it yields `INT_MIN`, and `abs(INT_MIN)` is also UB, so the subsequent `abs(bound) < BOUND_LIMIT` guard failed to reject the bogus value. Validate the double in [`-BOUND_LIMIT`, `BOUND_LIMIT`] (and isfinite) before casting.