### PR TITLE
Fix MaxSAT cost precision for large weight sums

### DIFF
--- a/extra/maxsat_evaluation/maxsat_evaluation_solver.h
+++ b/extra/maxsat_evaluation/maxsat_evaluation_solver.h
@@ -127,6 +127,27 @@ class MaxSATEvaluationSolver {
     }
 
     /*************************************************************************/
+    /**
+     * Recompute the soft-clause cost exactly in uint64_t from the original
+     * WCNF weights and the per-clause violation flags carried by the
+     * "soft_slacks" proxy. The model's internal objective is accumulated in
+     * double, so for weight sums exceeding 2^53 the double value loses lower
+     * bits and the printed `o`-line would drift from the true integer cost
+     * (and for sums approaching 2^63, the long-long cast itself would be UB).
+     * Computing here from the uint64_t weights avoids both problems.
+     */
+    inline uint64_t exact_cost(const std::vector<int> &a_SLACKS) const {
+        const size_t N = m_wcnf.soft_clauses.size();
+        uint64_t cost = 0;
+        for (size_t i = 0; i < N && i < a_SLACKS.size(); ++i) {
+            if (a_SLACKS[i] != 0) {
+                cost += m_wcnf.soft_clauses[i].weight;
+            }
+        }
+        return cost;
+    }
+
+    /*************************************************************************/
     inline void emit_solution(const solution::IPDenseSolution &a_SOLUTION) {
         /**
          * The first variable proxy named "variables" holds x_1..x_n in
@@ -144,8 +165,15 @@ class MaxSATEvaluationSolver {
             }
         }
 
-        const long long COST = static_cast<long long>(
-            std::llround(static_cast<double>(a_SOLUTION.objective)));
+        /**
+         * In import_wcnf the "variables" proxy is created first and
+         * "soft_slacks" immediately after, so the slacks live at index 1.
+         */
+        const uint64_t COST =
+            a_SOLUTION.variable_value_proxies.size() >= 2
+                ? exact_cost(a_SOLUTION.variable_value_proxies[1]
+                                 .flat_indexed_values())
+                : 0;
         std::cout << "o " << COST << "\n";
         std::cout << "v " << v_line << std::endl;
 
@@ -179,8 +207,8 @@ class MaxSATEvaluationSolver {
                 for (auto i = 0; i < N; i++) {
                     v_line.push_back(VALUES[i] != 0 ? '1' : '0');
                 }
-                const long long COST =
-                    static_cast<long long>(std::llround(FINAL_COST));
+                const uint64_t COST = exact_cost(
+                    SOLUTION.variables("soft_slacks").flat_indexed_values());
                 std::cout << "o " << COST << "\n";
                 std::cout << "v " << v_line << std::endl;
                 m_have_emitted_solution = true;

--- a/test/dat/wcnf/test_00e.wcnf
+++ b/test/dat/wcnf/test_00e.wcnf
@@ -1,0 +1,7 @@
+c precision stress: weights ~2^60. With x1=1 the violated soft cost is
+c 2^60 + 1 = 1152921504606846977, which rounds to 2^60 in double, so a
+c double-derived o-line would mis-report it.
+h 1 -1 0
+1152921504606846976 -1 0
+1 -1 0
+1152921504606846976 1 0

--- a/test/extra/maxsat_evaluation/test_maxsat_evaluation_solver.cpp
+++ b/test/extra/maxsat_evaluation/test_maxsat_evaluation_solver.cpp
@@ -105,6 +105,86 @@ TEST_F(TestMaxSATEvaluationSolver, solve_test_00a) {
     }
 }
 
+/*****************************************************************************/
+TEST_F(TestMaxSATEvaluationSolver, solve_test_00e_precision) {
+    /**
+     * test_00e: precision stress. Soft clauses carry weights ~2^60 so that
+     * the double-typed internal objective can no longer distinguish costs
+     * that differ by 1. The o-line must still match the exact uint64_t
+     * cost of the returned assignment.
+     *
+     * Layout:
+     *   hard:  (x1 OR ~x1)             -- always satisfied
+     *   soft:  w=2^60  (~x1)
+     *   soft:  w=1     (~x1)
+     *   soft:  w=2^60  ( x1)
+     *
+     *   x1 = 0  ->  violated weight = 2^60       (= 1152921504606846976)
+     *   x1 = 1  ->  violated weight = 2^60 + 1   (= 1152921504606846977)
+     *
+     * Under double accumulation 2^60 + 1 rounds to 2^60, so a
+     * double-derived o-line would print 1152921504606846976 for x1 = 1.
+     * The exact uint64_t recomputation must print 1152921504606846977.
+     */
+    std::string captured;
+    const int   EXIT_CODE =
+        run_and_capture("./test/dat/wcnf/test_00e.wcnf", "2", &captured);
+
+    EXPECT_EQ(10, EXIT_CODE);
+    EXPECT_NE(std::string::npos, captured.find("s SATISFIABLE"));
+
+    /**
+     * Parse the final (last) o-line and v-line and verify their mutual
+     * consistency in uint64_t, since the solver is free to settle on
+     * either x1 = 0 or x1 = 1 (the double objective sees them as equal).
+     */
+    auto find_last_line_starting_with =
+        [&captured](const std::string &a_PREFIX) -> size_t {
+        size_t pos     = std::string::npos;
+        size_t cursor  = 0;
+        while (true) {
+            const size_t HIT = captured.find(a_PREFIX, cursor);
+            if (HIT == std::string::npos) break;
+            if (HIT == 0 || captured[HIT - 1] == '\n') {
+                pos = HIT;
+            }
+            cursor = HIT + 1;
+        }
+        return pos;
+    };
+
+    const auto LAST_O = find_last_line_starting_with("o ");
+    const auto LAST_V = find_last_line_starting_with("v ");
+    ASSERT_NE(std::string::npos, LAST_O);
+    ASSERT_NE(std::string::npos, LAST_V);
+
+    const auto O_END = captured.find('\n', LAST_O);
+    const auto V_END = captured.find('\n', LAST_V);
+    ASSERT_NE(std::string::npos, O_END);
+    ASSERT_NE(std::string::npos, V_END);
+
+    const std::string O_VALUE =
+        captured.substr(LAST_O + 2, O_END - (LAST_O + 2));
+    const std::string V_BITS =
+        captured.substr(LAST_V + 2, V_END - (LAST_V + 2));
+
+    ASSERT_EQ(1u, V_BITS.size());
+    ASSERT_TRUE(V_BITS[0] == '0' || V_BITS[0] == '1');
+
+    const uint64_t W       = static_cast<uint64_t>(1) << 60;
+    const uint64_t EXPECTED = (V_BITS[0] == '1') ? (W + 1) : W;
+
+    EXPECT_EQ(std::to_string(EXPECTED), O_VALUE);
+
+    /**
+     * Sanity: ensure the printed o-value is not the double-truncated
+     * version (this is the exact bug the test is guarding against).
+     */
+    if (V_BITS[0] == '1') {
+        EXPECT_NE(std::to_string(W), O_VALUE);
+    }
+}
+
 }  // namespace
 /*****************************************************************************/
 // END


### PR DESCRIPTION
This is a follow-up to #238, and I included this change to the Max-SAT Evaluation 2026 submission.

## Summary
This PR fixes precision loss in the MaxSAT objective value output for instances with large soft-clause weight sums. The internal PRINTEMPS optimizer uses `double` for the objective, which loses precision for sums beyond ~2^53. The solution output now recomputes the cost exactly in `uint64_t` from the original WCNF weights and violation flags.

## Key Changes
- Added `exact_cost()` method that computes the total soft-clause cost by summing weights of violated clauses using `uint64_t` arithmetic, avoiding floating-point precision loss
- Updated `emit_solution()` to call `exact_cost()` with the soft-clause slack variables instead of rounding the accumulated `double` objective
- Updated the fallback cost computation in the anytime solver path to also use `exact_cost()`
- Updated README to document that the `o`-line is now exact for any weight sum fitting in `uint64_t`, while the internal `double` objective is only used for search and incumbent comparison

## Implementation Details
- The soft-clause slack variables are stored at index 1 in the variable proxies (created immediately after the main variables proxy in `import_wcnf`)
- The method safely handles cases where the proxy vector is smaller than expected by returning 0
- This approach maintains the existing search behavior while ensuring the reported solution cost is always exact