### PR TITLE
Augment fixed variable values for negated variables and product variables

### DIFF
--- a/printemps/standalone/standalone.h
+++ b/printemps/standalone/standalone.h
@@ -169,9 +169,12 @@ class Standalone {
          * be fixed at the specified values.
          */
         if (!m_argparser.fixed_variable_file_name.empty()) {
-            const auto FIXED_VARIABLES_AND_VALUES =
+            auto FIXED_VARIABLES_AND_VALUES =
                 printemps::helper::read_names_and_values(
                     m_argparser.fixed_variable_file_name);
+            if (EXTENSION == "opb" || EXTENSION == "wbo") {
+                m_opb.augment_solution(FIXED_VARIABLES_AND_VALUES);
+            }
             m_model.fix_variables(FIXED_VARIABLES_AND_VALUES);
         }
 


### PR DESCRIPTION
Apply the same augmentation logic used for initial solutions (#242) to the fixed variable file specified via `-f`.

Users providing fixed variable values for OPB/WBO instances should not need to know about PRINTEMPS's internal representation of negated literals or product variables; if a user fixes `x` to a value, the negated variable `~x` and any fully-determined product variable involving `x` should also be fixed accordingly.