### PR TITLE
Add -i and -f options to pb_competition_2025 solver

### DIFF
--- a/extra/pb_competition_2025/pb_competition_2025_solver.h
+++ b/extra/pb_competition_2025/pb_competition_2025_solver.h
@@ -148,6 +148,18 @@ class PBCompetition2025Solver {
         m_model.set_name(
             printemps::utility::base_name(m_argparser.pb_file_name));
 
+        /**
+         * If the initial solution file is given, the values of the variables
+         * in the file will be used as the initial values. Otherwise, the
+         * default values will be used.
+         */
+        if (!m_argparser.initial_solution_file_name.empty()) {
+            auto INITIAL_SOLUTION = printemps::helper::read_names_and_values(
+                m_argparser.initial_solution_file_name);
+            m_opb.augment_solution(INITIAL_SOLUTION);
+            m_model.import_solution(INITIAL_SOLUTION);
+        }
+
         if (m_argparser.is_specified_iteration_max) {
             m_option.general.iteration_max = m_argparser.iteration_max;
         }

--- a/extra/pb_competition_2025/pb_competition_2025_solver.h
+++ b/extra/pb_competition_2025/pb_competition_2025_solver.h
@@ -160,6 +160,17 @@ class PBCompetition2025Solver {
             m_model.import_solution(INITIAL_SOLUTION);
         }
 
+        /**
+         * If the fixed variable file is given, the values of the variables will
+         * be fixed at the specified values.
+         */
+        if (!m_argparser.fixed_variable_file_name.empty()) {
+            const auto FIXED_VARIABLES_AND_VALUES =
+                printemps::helper::read_names_and_values(
+                    m_argparser.fixed_variable_file_name);
+            m_model.fix_variables(FIXED_VARIABLES_AND_VALUES);
+        }
+
         if (m_argparser.is_specified_iteration_max) {
             m_option.general.iteration_max = m_argparser.iteration_max;
         }

--- a/extra/pb_competition_2025/pb_competition_2025_solver.h
+++ b/extra/pb_competition_2025/pb_competition_2025_solver.h
@@ -165,9 +165,10 @@ class PBCompetition2025Solver {
          * be fixed at the specified values.
          */
         if (!m_argparser.fixed_variable_file_name.empty()) {
-            const auto FIXED_VARIABLES_AND_VALUES =
+            auto FIXED_VARIABLES_AND_VALUES =
                 printemps::helper::read_names_and_values(
                     m_argparser.fixed_variable_file_name);
+            m_opb.augment_solution(FIXED_VARIABLES_AND_VALUES);
             m_model.fix_variables(FIXED_VARIABLES_AND_VALUES);
         }
 

--- a/extra/pb_competition_2025/pb_competition_2025_solver_argparser.h
+++ b/extra/pb_competition_2025/pb_competition_2025_solver_argparser.h
@@ -17,6 +17,7 @@ struct PBCompetition2025SolverArgparserConstant {
 struct PBCompetition2025SolverArgparser {
     std::string pb_file_name;
     std::string initial_solution_file_name;
+    std::string fixed_variable_file_name;
 
     double iteration_max;
     double time_max;
@@ -37,6 +38,7 @@ struct PBCompetition2025SolverArgparser {
     inline void initialize(void) {
         this->pb_file_name.clear();
         this->initial_solution_file_name.clear();
+        this->fixed_variable_file_name.clear();
 
         this->iteration_max =
             option::GeneralOptionConstant::DEFAULT_ITERATION_MAX;
@@ -65,6 +67,7 @@ struct PBCompetition2025SolverArgparser {
                   << "[-j NUMBER_OF_THREADS] "
                   << "[-r SEED] "
                   << "[-i INITIAL_SOLUTION_FILE] "
+                  << "[-f FIXED_VARIABLE_FILE] "
                   << "opb_file" << std::endl;
         std::cout << std::endl;
         std::cout  //
@@ -90,6 +93,10 @@ struct PBCompetition2025SolverArgparser {
         std::cout  //
             << "  -i INITIAL_SOLUTION_FILE: Specify the file name of an "
                "initial solution."
+            << std::endl;
+        std::cout  //
+            << "  -f FIXED_VARIABLE_FILE: Specify the file name of fixed "
+               "variables and their values."
             << std::endl;
     }
 
@@ -117,6 +124,9 @@ struct PBCompetition2025SolverArgparser {
                 i += 2;
             } else if (args[i] == "-i") {
                 this->initial_solution_file_name = args[i + 1];
+                i += 2;
+            } else if (args[i] == "-f") {
+                this->fixed_variable_file_name = args[i + 1];
                 i += 2;
             } else {
                 this->pb_file_name = args[i];

--- a/extra/pb_competition_2025/pb_competition_2025_solver_argparser.h
+++ b/extra/pb_competition_2025/pb_competition_2025_solver_argparser.h
@@ -16,6 +16,7 @@ struct PBCompetition2025SolverArgparserConstant {
 /*****************************************************************************/
 struct PBCompetition2025SolverArgparser {
     std::string pb_file_name;
+    std::string initial_solution_file_name;
 
     double iteration_max;
     double time_max;
@@ -35,6 +36,7 @@ struct PBCompetition2025SolverArgparser {
     /*************************************************************************/
     inline void initialize(void) {
         this->pb_file_name.clear();
+        this->initial_solution_file_name.clear();
 
         this->iteration_max =
             option::GeneralOptionConstant::DEFAULT_ITERATION_MAX;
@@ -62,6 +64,7 @@ struct PBCompetition2025SolverArgparser {
                   << "[-t TIME_MAX] "
                   << "[-j NUMBER_OF_THREADS] "
                   << "[-r SEED] "
+                  << "[-i INITIAL_SOLUTION_FILE] "
                   << "opb_file" << std::endl;
         std::cout << std::endl;
         std::cout  //
@@ -84,6 +87,10 @@ struct PBCompetition2025SolverArgparser {
         std::cout  //
             << "  -r SEED: Specify the random seed. (default: "
             << option::GeneralOptionConstant::DEFAULT_SEED << ")" << std::endl;
+        std::cout  //
+            << "  -i INITIAL_SOLUTION_FILE: Specify the file name of an "
+               "initial solution."
+            << std::endl;
     }
 
     /*************************************************************************/
@@ -107,6 +114,9 @@ struct PBCompetition2025SolverArgparser {
                 this->seed = static_cast<int32_t>(
                     static_cast<uint32_t>(std::stol(args[i + 1])));
                 this->is_specified_seed = true;
+                i += 2;
+            } else if (args[i] == "-i") {
+                this->initial_solution_file_name = args[i + 1];
                 i += 2;
             } else {
                 this->pb_file_name = args[i];


### PR DESCRIPTION
Add `-i` and `-f` options to `pb_competition_2025` solver  that mirrors the standalone solver's flags.

I used those flags in [the submission](https://github.com/msakai/printemps-pb/releases/tag/PB25-submission-20250528) for the Pseudo Boolean Competition 2026, though I forgot to augment negated/product variable values for fixing variables.

With regard to augmentation, see also:
- #242
- #248

BTW, maybe it's time to rename `pb_competition_2025` to `pb_competition`.